### PR TITLE
ci: deploy emotes-service to staging then prod on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ env:
   TURBO_SCM_HEAD: ${{ github.sha }}
 
 jobs:
-  deploy-staging:
+  deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,73 @@
+name: Main
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: deploy-main
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  DO_NOT_TRACK: 1
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+  TURBO_SCM_BASE: ${{ github.event.before }}
+  TURBO_SCM_HEAD: ${{ github.sha }}
+
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Authenticate with Pulumi Cloud
+        uses: pulumi/auth-actions@v1
+        with:
+          organization: aaronkik
+          requested-token-type: urn:pulumi:token-type:access_token:personal
+          scope: user:aaronkik
+      - name: Deploy staging
+        run: turbo run deploy:staging --affected
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          NEXT_PUBLIC_TWITCH_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_TWITCH_CLIENT_ID }}
+          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
+
+  deploy-prod:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - deploy-staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Authenticate with Pulumi Cloud
+        uses: pulumi/auth-actions@v1
+        with:
+          organization: aaronkik
+          requested-token-type: urn:pulumi:token-type:access_token:personal
+          scope: user:aaronkik
+      - name: Deploy prod
+        run: turbo run deploy:prod --affected
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          NEXT_PUBLIC_TWITCH_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_TWITCH_CLIENT_ID }}
+          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,6 @@ jobs:
         run: turbo run deploy:staging --affected
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          NEXT_PUBLIC_TWITCH_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_TWITCH_CLIENT_ID }}
-          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
 
   deploy-prod:
     runs-on: ubuntu-latest
@@ -69,5 +67,3 @@ jobs:
         run: turbo run deploy:prod --affected
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          NEXT_PUBLIC_TWITCH_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_TWITCH_CLIENT_ID }}
-          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
   deploy-staging:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -40,30 +42,5 @@ jobs:
           scope: user:aaronkik
       - name: Deploy staging
         run: turbo run deploy:staging --affected
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-
-  deploy-prod:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs:
-      - deploy-staging
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Setup mise
-        uses: jdx/mise-action@v4
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-      - name: Authenticate with Pulumi Cloud
-        uses: pulumi/auth-actions@v1
-        with:
-          organization: aaronkik
-          requested-token-type: urn:pulumi:token-type:access_token:personal
-          scope: user:aaronkik
       - name: Deploy prod
         run: turbo run deploy:prod --affected
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/apps/emotes-service/Taskfile.yml
+++ b/apps/emotes-service/Taskfile.yml
@@ -15,10 +15,34 @@ tasks:
     desc: Creates a stack in pulumi with ESC values
     cmds:
       - |
-        if ! pulumi stack select -s $PULUMI_STACK 2>/dev/null; then                                                   
+        if ! pulumi stack select -s $PULUMI_STACK 2>/dev/null; then
           pulumi stack init -s $PULUMI_STACK
         fi
       - pulumi config env add emotes-service/dev --yes
+      - pulumi config env add emotes-service/twitch-credentials --yes
+
+  create:staging:
+    desc: Creates the staging stack in pulumi with ESC values
+    env:
+      PULUMI_STACK: staging
+    cmds:
+      - |
+        if ! pulumi stack select -s $PULUMI_STACK 2>/dev/null; then
+          pulumi stack init -s $PULUMI_STACK
+        fi
+      - pulumi config env add emotes-service/staging --yes
+      - pulumi config env add emotes-service/twitch-credentials --yes
+
+  create:prod:
+    desc: Creates the prod stack in pulumi with ESC values
+    env:
+      PULUMI_STACK: prod
+    cmds:
+      - |
+        if ! pulumi stack select -s $PULUMI_STACK 2>/dev/null; then
+          pulumi stack init -s $PULUMI_STACK
+        fi
+      - pulumi config env add emotes-service/prod --yes
       - pulumi config env add emotes-service/twitch-credentials --yes
 
   preview:
@@ -33,6 +57,26 @@ tasks:
     deps:
       - build
     cmds:
+      - pulumi up --yes
+
+  deploy:staging:
+    desc: Deploys IaC to staging
+    deps:
+      - build
+    env:
+      PULUMI_STACK: staging
+    cmds:
+      - task: create:staging
+      - pulumi up --yes
+
+  deploy:prod:
+    desc: Deploys IaC to prod
+    deps:
+      - build
+    env:
+      PULUMI_STACK: prod
+    cmds:
+      - task: create:prod
       - pulumi up --yes
 
   destroy:ci:

--- a/apps/emotes-service/package.json
+++ b/apps/emotes-service/package.json
@@ -11,6 +11,8 @@
     "create": "task create",
     "preview": "task preview",
     "deploy": "task deploy",
+    "deploy:staging": "task deploy:staging",
+    "deploy:prod": "task deploy:prod",
     "destroy:local": "task destroy:local",
     "destroy:ci": "task destroy:ci"
   }

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,12 @@
     "deploy": {
       "cache": false
     },
+    "deploy:staging": {
+      "cache": false
+    },
+    "deploy:prod": {
+      "cache": false
+    },
     "preview": {
       "cache": false
     },

--- a/turbo.json
+++ b/turbo.json
@@ -24,10 +24,10 @@
       "cache": false
     },
     "deploy:staging": {
-      "cache": false
+      "cache": true
     },
     "deploy:prod": {
-      "cache": false
+      "cache": true
     },
     "preview": {
       "cache": false


### PR DESCRIPTION
## Summary
- Add `deploy:staging` / `deploy:prod` Taskfile tasks (with matching `create:staging` / `create:prod`) that hardcode `PULUMI_STACK` and bind `emotes-service/staging` or `emotes-service/prod` ESC envs.
- Expose those tasks via `package.json` scripts and register them in root `turbo.json` (`cache: false`).
- New `.github/workflows/main.yml`: on push to `main`, run `turbo run deploy:staging --affected`, then `deploy:prod` once staging succeeds. Twitch + Pulumi creds passed through; AWS comes from the bound ESC env.

## Test plan
- [ ] Confirm `emotes-service/staging` and `emotes-service/prod` ESC envs exist in Pulumi Cloud and export AWS creds + region.
- [ ] PR run: existing `pr.yml` still green (new workflow does not trigger on PRs).
- [ ] After merge: `deploy-staging` job runs, `pulumi stack init staging` succeeds (first run), `pulumi config env add emotes-service/staging` succeeds, `pulumi up` completes.
- [ ] `deploy-prod` runs after staging; same checks against `prod`.
- [ ] Pulumi Cloud shows both stacks with their ESC envs bound.
- [ ] Push a no-op commit to `main`; emotes-service deploy is skipped by `--affected`.