### PR TITLE
ci: scope PULUMI_ACCESS_TOKEN to deploy steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -42,5 +40,9 @@ jobs:
           scope: user:aaronkik
       - name: Deploy staging
         run: turbo run deploy:staging --affected
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - name: Deploy prod
         run: turbo run deploy:prod --affected
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Move `PULUMI_ACCESS_TOKEN` from job-level `env` onto the two `Deploy staging` / `Deploy prod` steps that need it. No other step in the job uses the token, so narrowing scope keeps the secret out of unrelated step environments.

## Test plan
- [ ] Next push to `main` runs the workflow and both `pulumi up` steps still authenticate against Pulumi Cloud.