### PR TITLE
build: pass AWS and Pulumi env to deploy tasks

### DIFF
--- a/apps/emotes-service/turbo.json
+++ b/apps/emotes-service/turbo.json
@@ -13,6 +13,24 @@
         "AWS_REGION",
         "PULUMI_ACCESS_TOKEN"
       ]
+    },
+    "deploy:staging": {
+      "env": [
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_REGION",
+        "PULUMI_ACCESS_TOKEN"
+      ]
+    },
+    "deploy:prod": {
+      "env": [
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_REGION",
+        "PULUMI_ACCESS_TOKEN"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add env passthrough for `deploy:staging` and `deploy:prod` turbo tasks so AWS credentials and `PULUMI_ACCESS_TOKEN` reach Pulumi during deploy.

## Test plan
- [ ] CI deploy job runs `deploy:staging` and `deploy:prod` with env vars available
- [ ] Pulumi authenticates and applies stack changes