### PR TITLE
ci: destroy ephemeral PR stacks on close

### DIFF
--- a/.github/workflows/destroy-iac.yml
+++ b/.github/workflows/destroy-iac.yml
@@ -1,0 +1,52 @@
+name: Destroy IaC
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  DO_NOT_TRACK: 1
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+  PR_NUMBER: ${{ github.event.pull_request.number }}
+
+jobs:
+  destroy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Authenticate with Pulumi Cloud
+        uses: pulumi/auth-actions@v1
+        with:
+          organization: aaronkik
+          requested-token-type: urn:pulumi:token-type:access_token:personal
+          scope: user:aaronkik
+      - name: Check stack exists
+        id: stack
+        working-directory: apps/emotes-service
+        run: |
+          if pulumi stack select -s "pr-${PR_NUMBER}" 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No Pulumi stack pr-${PR_NUMBER} found; nothing to destroy."
+          fi
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+      - name: Destroy PR stack
+        if: steps.stack.outputs.exists == 'true'
+        run: turbo run destroy:ci --filter=emotes-service
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/destroy-iac.yml
+++ b/.github/workflows/destroy-iac.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     types: [closed]
 
+  workflow_dispatch:
+    inputs:
+      stack_name:
+        description: Pulumi stack name to destroy (e.g. pr-42)
+        required: true
+        type: string
+
 permissions:
   id-token: write
   contents: read
@@ -12,7 +19,7 @@ env:
   DO_NOT_TRACK: 1
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-  PR_NUMBER: ${{ github.event.pull_request.number }}
+  CI_STACK_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.stack_name || format('pr-{0}', github.event.pull_request.number) }}
 
 jobs:
   destroy:
@@ -37,15 +44,15 @@ jobs:
         id: stack
         working-directory: apps/emotes-service
         run: |
-          if pulumi stack select -s "pr-${PR_NUMBER}" 2>/dev/null; then
+          if pulumi stack select -s "${CI_STACK_NAME}" 2>/dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "No Pulumi stack pr-${PR_NUMBER} found; nothing to destroy."
+            echo "No Pulumi stack ${CI_STACK_NAME} found; nothing to destroy."
           fi
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-      - name: Destroy PR stack
+      - name: Destroy stack
         if: steps.stack.outputs.exists == 'true'
         run: turbo run destroy:ci --filter=emotes-service
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
   TURBO_SCM_BASE: origin/${{ github.base_ref }}
-  PR_NUMBER: ${{ github.event.pull_request.number }}
+  CI_STACK_NAME: pr-${{ github.event.pull_request.number }}
 
 jobs:
   lint-build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,7 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
   TURBO_SCM_BASE: origin/${{ github.base_ref }}
+  PR_NUMBER: ${{ github.event.pull_request.number }}
 
 jobs:
   lint-build:

--- a/apps/emotes-service/infra/main.go
+++ b/apps/emotes-service/infra/main.go
@@ -5,7 +5,6 @@ import (
 	"emotes-service/infra/git"
 	"emotes-service/infra/stack"
 	"strings"
-	"time"
 
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws"
 	"github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice"
@@ -21,7 +20,7 @@ func main() {
 			return err
 		}
 
-		deploymentSettings, err := pulumiservice.NewDeploymentSettings(ctx, "deployment-settings-resource", &pulumiservice.DeploymentSettingsArgs{
+		_, err = pulumiservice.NewDeploymentSettings(ctx, "deployment-settings-resource", &pulumiservice.DeploymentSettingsArgs{
 			Organization: pulumi.String(ctx.Organization()),
 			Project:      pulumi.String(ctx.Project()),
 			Stack:        pulumi.String(ctx.Stack()),
@@ -43,22 +42,6 @@ func main() {
 		})
 		if err != nil {
 			return err
-		}
-
-		now := time.Now().UTC()
-		daysUntilSunday := (7 - int(now.Weekday())) % 7
-		stackDestruction := time.Date(now.Year(), now.Month(), now.Day()+daysUntilSunday, 23, 59, 59, 0, time.UTC)
-
-		if stack.IsEphemeral(ctx.Stack()) {
-			_, err = pulumiservice.NewTtlSchedule(ctx, "ttl-schedule", &pulumiservice.TtlScheduleArgs{
-				Organization: pulumi.String(ctx.Organization()),
-				Project:      pulumi.String(ctx.Project()),
-				Stack:        pulumi.String(ctx.Stack()),
-				Timestamp:    pulumi.String(stackDestruction.UTC().Format(time.RFC3339)),
-			}, pulumi.DependsOn([]pulumi.Resource{deploymentSettings}))
-			if err != nil {
-				return err
-			}
 		}
 
 		awsConfig := config.New(ctx, "aws")

--- a/apps/emotes-service/scripts/stack-name.sh
+++ b/apps/emotes-service/scripts/stack-name.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-if [[ "${CI:-}" == "true" && "${GITHUB_REF:-}" =~ ^refs/pull/([0-9]+)/ ]]; then
-  echo "pr-${BASH_REMATCH[1]}"
+# PR_NUMBER is set in CI environments
+if [[ -n "${PR_NUMBER:-}" ]]; then
+  echo "pr-${PR_NUMBER}"
   exit 0
 fi
 

--- a/apps/emotes-service/scripts/stack-name.sh
+++ b/apps/emotes-service/scripts/stack-name.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-# PR_NUMBER is set in CI environments
-if [[ -n "${PR_NUMBER:-}" ]]; then
-  echo "pr-${PR_NUMBER}"
+# CI_STACK_NAME is set by CI workflows.
+if [[ -n "${CI_STACK_NAME:-}" ]]; then
+  echo "${CI_STACK_NAME}"
   exit 0
 fi
 

--- a/apps/emotes-service/turbo.json
+++ b/apps/emotes-service/turbo.json
@@ -12,7 +12,7 @@
         "AWS_SESSION_TOKEN",
         "AWS_REGION",
         "PULUMI_ACCESS_TOKEN",
-        "PR_NUMBER"
+        "CI_STACK_NAME"
       ]
     },
     "deploy:staging": {
@@ -41,7 +41,7 @@
         "AWS_SESSION_TOKEN",
         "AWS_REGION",
         "PULUMI_ACCESS_TOKEN",
-        "PR_NUMBER"
+        "CI_STACK_NAME"
       ]
     }
   }

--- a/apps/emotes-service/turbo.json
+++ b/apps/emotes-service/turbo.json
@@ -11,7 +11,8 @@
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SESSION_TOKEN",
         "AWS_REGION",
-        "PULUMI_ACCESS_TOKEN"
+        "PULUMI_ACCESS_TOKEN",
+        "PR_NUMBER"
       ]
     },
     "deploy:staging": {
@@ -39,7 +40,8 @@
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SESSION_TOKEN",
         "AWS_REGION",
-        "PULUMI_ACCESS_TOKEN"
+        "PULUMI_ACCESS_TOKEN",
+        "PR_NUMBER"
       ]
     }
   }

--- a/apps/emotes-service/turbo.json
+++ b/apps/emotes-service/turbo.json
@@ -31,6 +31,16 @@
         "AWS_REGION",
         "PULUMI_ACCESS_TOKEN"
       ]
+    },
+    "destroy:ci": {
+      "cache": false,
+      "env": [
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_REGION",
+        "PULUMI_ACCESS_TOKEN"
+      ]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": ["PR_NUMBER"],
   "tasks": {
     "build": {
       "env": ["NEXT_PUBLIC_TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET"]

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["PR_NUMBER"],
   "tasks": {
     "build": {
       "env": ["NEXT_PUBLIC_TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET"]


### PR DESCRIPTION
## Summary
- New workflow `destroy-iac.yml` runs `turbo destroy:ci --filter=emotes-service` on `pull_request: closed`, with a guard step that no-ops when the `pr-N` stack was never provisioned.
- Switch `stack-name.sh` to read `PR_NUMBER` env (set in both PR workflows from `github.event.pull_request.number`). Previous `GITHUB_REF` regex silently fell back to `whoami` on merged-closed events because `GITHUB_REF` flips to `refs/heads/<base>`.
- Drop TTL-based teardown in `infra/main.go` — superseded by the destroy workflow.

## Test plan
- [ ] Open throwaway PR touching `apps/emotes-service`, let `pr.yml ci-test` provision `pr-N` stack
- [ ] Close PR without merging → `destroy-iac.yml` runs, guard sees `exists=true`, stack removed
- [ ] Open + merge another throwaway → confirm destroy still resolves `pr-N` (the bug-fix path)
- [ ] Open PR not touching emotes-service → close → guard sees `exists=false`, destroy skipped, workflow green