### PR TITLE
refactor(emotes-service): consolidate destroy:ci guard in Taskfile

### DIFF
--- a/.github/workflows/destroy-iac.yml
+++ b/.github/workflows/destroy-iac.yml
@@ -40,20 +40,7 @@ jobs:
           organization: aaronkik
           requested-token-type: urn:pulumi:token-type:access_token:personal
           scope: user:aaronkik
-      - name: Check stack exists
-        id: stack
-        working-directory: apps/emotes-service
-        run: |
-          if pulumi stack select -s "${CI_STACK_NAME}" 2>/dev/null; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "No Pulumi stack ${CI_STACK_NAME} found; nothing to destroy."
-          fi
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - name: Destroy stack
-        if: steps.stack.outputs.exists == 'true'
         run: turbo run destroy:ci --filter=emotes-service
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/destroy-iac.yml
+++ b/.github/workflows/destroy-iac.yml
@@ -41,6 +41,6 @@ jobs:
           requested-token-type: urn:pulumi:token-type:access_token:personal
           scope: user:aaronkik
       - name: Destroy stack
-        run: turbo run destroy:ci --filter=emotes-service
+        run: turbo run destroy:ci
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/apps/emotes-service/Taskfile.yml
+++ b/apps/emotes-service/Taskfile.yml
@@ -82,6 +82,7 @@ tasks:
   destroy:ci:
     desc: Teardown a stack from Pulumi and AWS without prompt
     cmds:
+      - pulumi config env add emotes-service/dev --yes
       - pulumi destroy --yes
       - pulumi stack rm $PULUMI_STACK --yes
 

--- a/apps/emotes-service/Taskfile.yml
+++ b/apps/emotes-service/Taskfile.yml
@@ -81,23 +81,11 @@ tasks:
 
   destroy:ci:
     desc: Teardown a stack from Pulumi and AWS without prompt; no-op if stack absent
-    vars:
-      STACK_EXISTS:
-        sh: |
-          if pulumi stack select -s "$PULUMI_STACK" 2>/dev/null; then
-            echo true
-          else
-            echo false
-          fi
+    if: 'pulumi stack select -s "$PULUMI_STACK" 2>/dev/null'
     cmds:
-      - if: '{{eq .STACK_EXISTS "false"}}'
-        cmd: echo "No Pulumi stack $PULUMI_STACK found, skipping destroy."
-      - if: '{{eq .STACK_EXISTS "true"}}'
-        cmd: pulumi config env add emotes-service/dev --yes
-      - if: '{{eq .STACK_EXISTS "true"}}'
-        cmd: pulumi destroy --yes
-      - if: '{{eq .STACK_EXISTS "true"}}'
-        cmd: pulumi stack rm $PULUMI_STACK --yes
+      - pulumi config env add emotes-service/dev --yes
+      - pulumi destroy --yes
+      - pulumi stack rm $PULUMI_STACK --yes
 
   destroy:local:
     desc: Teardown a stack from Pulumi and AWS

--- a/apps/emotes-service/Taskfile.yml
+++ b/apps/emotes-service/Taskfile.yml
@@ -80,11 +80,24 @@ tasks:
       - pulumi up --yes
 
   destroy:ci:
-    desc: Teardown a stack from Pulumi and AWS without prompt
+    desc: Teardown a stack from Pulumi and AWS without prompt; no-op if stack absent
+    vars:
+      STACK_EXISTS:
+        sh: |
+          if pulumi stack select -s "$PULUMI_STACK" 2>/dev/null; then
+            echo true
+          else
+            echo false
+          fi
     cmds:
-      - pulumi config env add emotes-service/dev --yes
-      - pulumi destroy --yes
-      - pulumi stack rm $PULUMI_STACK --yes
+      - if: '{{eq .STACK_EXISTS "false"}}'
+        cmd: echo "No Pulumi stack $PULUMI_STACK found, skipping destroy."
+      - if: '{{eq .STACK_EXISTS "true"}}'
+        cmd: pulumi config env add emotes-service/dev --yes
+      - if: '{{eq .STACK_EXISTS "true"}}'
+        cmd: pulumi destroy --yes
+      - if: '{{eq .STACK_EXISTS "true"}}'
+        cmd: pulumi stack rm $PULUMI_STACK --yes
 
   destroy:local:
     desc: Teardown a stack from Pulumi and AWS


### PR DESCRIPTION
## Summary
- Re-attach `emotes-service/dev` ESC env before `pulumi destroy` so manual `workflow_dispatch` runs against orphaned stacks have AWS credentials.
- Use Task's task-level `if:` control to no-op `destroy:ci` when the stack is absent — replaces the per-step guard previously living in `destroy-iac.yml`.
- Drop `--filter=emotes-service` from the destroy workflow so future packages with their own `destroy:ci` task are also torn down.

Refs #16

## Test plan
- [ ] `PULUMI_STACK=does-not-exist task destroy:ci` exits cleanly with no Pulumi calls
- [ ] Open throwaway PR, let `pr.yml` provision `pr-N`, close it → `destroy-iac.yml` succeeds and Pulumi stack is gone
- [ ] `gh workflow run destroy-iac.yml -f stack_name=runne` cleans up the orphaned `runne` stack