### PR TITLE
chore(infra): remove unused snapshots table

### DIFF
--- a/apps/emotes-service/infra/components/stateful.go
+++ b/apps/emotes-service/infra/components/stateful.go
@@ -10,36 +10,12 @@ import (
 type StatefulComponent struct {
 	pulumi.ResourceState
 	TwitchEmotesEmotesEventStoreTable *dynamodb.Table
-	TwitchEmotesSnapshotsTable        *dynamodb.Table
 }
 
 func NewStatefulComponent(ctx *pulumi.Context, providerResource pulumi.ResourceOption) (*StatefulComponent, error) {
 	component := &StatefulComponent{}
 
 	err := ctx.RegisterComponentResourceV2("emotes-service:index:StatefulComponent", "stateful", nil, component)
-	if err != nil {
-		return nil, err
-	}
-
-	twitchEmotesSnapshotsTable, err := dynamodb.NewTable(ctx, "twitch-emotes-snapshots", &dynamodb.TableArgs{
-		BillingMode: pulumi.String("PAY_PER_REQUEST"),
-		HashKey:     pulumi.String("PK"),
-		RangeKey:    pulumi.String("SK"),
-		Attributes: dynamodb.TableAttributeArray{
-			&dynamodb.TableAttributeArgs{
-				Name: pulumi.String("PK"),
-				Type: pulumi.String("S"),
-			},
-			&dynamodb.TableAttributeArgs{
-				Name: pulumi.String("SK"),
-				Type: pulumi.String("S"),
-			},
-		},
-		DeletionProtectionEnabled: pulumi.BoolPtr(false),
-	},
-		pulumi.Parent(component),
-		providerResource,
-	)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +44,6 @@ func NewStatefulComponent(ctx *pulumi.Context, providerResource pulumi.ResourceO
 	}
 
 	component.TwitchEmotesEmotesEventStoreTable = twitchEmotesEventStoreTable
-	component.TwitchEmotesSnapshotsTable = twitchEmotesSnapshotsTable
 
 	return component, nil
 }

--- a/apps/emotes-service/infra/components/stateless.go
+++ b/apps/emotes-service/infra/components/stateless.go
@@ -21,7 +21,6 @@ type StatelessComponent struct {
 
 type StatefulResource struct {
 	TwitchEmotesEventsStoreTable *dynamodb.Table
-	TwitchEmotesSnapshotsTable   *dynamodb.Table
 }
 
 func NewStatelessComponent(ctx *pulumi.Context, providerResource pulumi.ResourceOption, applicationConfig stack.ApplicationConfig, statefulResource StatefulResource) (*StatelessComponent, error) {
@@ -63,7 +62,6 @@ func NewStatelessComponent(ctx *pulumi.Context, providerResource pulumi.Resource
 			"bootstrap": pulumi.NewFileAsset("../dist/sync-global-emotes/bootstrap"),
 		}),
 		Environment: map[string]pulumi.StringInput{
-			"TWITCH_EMOTES_SNAPSHOT_TABLE":    pulumi.StringInput(statefulResource.TwitchEmotesSnapshotsTable.Name),
 			"TWITCH_EMOTES_EVENT_STORE_TABLE": pulumi.StringInput(statefulResource.TwitchEmotesEventsStoreTable.Name),
 			"TWITCH_GLOBAL_EMOTES_ENDPOINT":   applicationConfig.Twitch.GlobalEmotesEndpoint,
 			"TWITCH_OAUTH_ENDPOINT":           applicationConfig.Twitch.OauthEndpoint,
@@ -77,13 +75,6 @@ func NewStatelessComponent(ctx *pulumi.Context, providerResource pulumi.Resource
 				Resources: pulumi.StringArray{
 					twitchClientIdParam.Arn,
 					twitchClientSecretParam.Arn,
-				},
-			},
-			&iam.GetPolicyDocumentStatementArgs{
-				Effect:  pulumi.String("Allow"),
-				Actions: pulumi.StringArray{pulumi.String("dynamodb:PutItem")},
-				Resources: pulumi.StringArray{
-					statefulResource.TwitchEmotesSnapshotsTable.Arn,
 				},
 			},
 			&iam.GetPolicyDocumentStatementArgs{
@@ -104,7 +95,6 @@ func NewStatelessComponent(ctx *pulumi.Context, providerResource pulumi.Resource
 		pulumi.DependsOn([]pulumi.Resource{
 			twitchClientIdParam,
 			twitchClientSecretParam,
-			statefulResource.TwitchEmotesSnapshotsTable,
 		}))
 	if err != nil {
 		return nil, err

--- a/apps/emotes-service/infra/main.go
+++ b/apps/emotes-service/infra/main.go
@@ -85,7 +85,6 @@ func main() {
 
 		statelessComponent, err := components.NewStatelessComponent(ctx, providerResource, appConfig, components.StatefulResource{
 			TwitchEmotesEventsStoreTable: statefulComponent.TwitchEmotesEmotesEventStoreTable,
-			TwitchEmotesSnapshotsTable:   statefulComponent.TwitchEmotesSnapshotsTable,
 		})
 		if err != nil {
 			return err
@@ -94,7 +93,6 @@ func main() {
 		if integrationComponent != nil {
 			ctx.Export("syncGlobalEmotesLambdaName", statelessComponent.SyncGlobalEmotesFunction.Name)
 			ctx.Export("twitchEmotesEmotesEventStoreTable", statefulComponent.TwitchEmotesEmotesEventStoreTable.Name)
-			ctx.Export("twitchEmotesSnapshotsTableName", statefulComponent.TwitchEmotesSnapshotsTable.Name)
 			ctx.Export("mockTwitchResponsesTableName", integrationComponent.MockTwitchResponsesTable.Name)
 		}
 


### PR DESCRIPTION
## Summary
- Remove unused `twitch-emotes-snapshots` DynamoDB table and related IAM/env wiring from emotes-service infra.

## Test plan
- [ ] `pulumi preview` shows table deletion only, no other drift
- [ ] `sync-global-emotes` Lambda still deploys without `TWITCH_EMOTES_SNAPSHOT_TABLE` env var