### PR TITLE
chore(emotes-service): remove unused eventId attribute

### DIFF
--- a/apps/emotes-service/src/adapters/secondary/event_store/event_store.go
+++ b/apps/emotes-service/src/adapters/secondary/event_store/event_store.go
@@ -53,7 +53,6 @@ type EmoteServiceEvent struct {
 	CreatedAt   string                  `dynamodbav:"__createdAt"`
 	Emote       *EmoteServiceEventEmote `dynamodbav:"emote"`
 	EmoteId     string                  `dynamodbav:"emoteId"`
-	EventId     string                  `dynamodbav:"eventId"`
 	EventName   string                  `dynamodbav:"eventName"`
 	Id          string                  `dynamodbav:"id"`
 	Kind        string                  `dynamodbav:"kind"`
@@ -267,7 +266,6 @@ func createEmoteEvent(eventInput createEmoteEventInput) EmoteServiceEvent {
 		CreatedAt:   eventInput.CreatedAt,
 		Emote:       eventInput.Emote,
 		EmoteId:     eventInput.EmoteId,
-		EventId:     fmt.Sprintf("%s#%s", pk, sk),
 		EventName:   eventInput.EventName,
 		Id:          generateId(),
 		Kind:        "EVENT",

--- a/apps/emotes-service/src/tests/integration/global_emotes_test.go
+++ b/apps/emotes-service/src/tests/integration/global_emotes_test.go
@@ -73,7 +73,6 @@ func Test_Emote_Added_Event_Is_Added_To_Event_Store_When_Emote_Exists(t *testing
 
 	require.Equal("GLOBAL", emoteAddedEvent["aggregateId"].(*types.AttributeValueMemberS).Value)
 	require.Equal("1", emoteAddedEvent["emoteId"].(*types.AttributeValueMemberS).Value)
-	require.Equal("GLOBAL#SEQUENCE#0000001", emoteAddedEvent["eventId"].(*types.AttributeValueMemberS).Value)
 	require.Equal("EmoteAdded", emoteAddedEvent["eventName"].(*types.AttributeValueMemberS).Value)
 	require.Equal("EVENT", emoteAddedEvent["kind"].(*types.AttributeValueMemberS).Value)
 	require.Equal("1", emoteAddedEvent["sequence"].(*types.AttributeValueMemberN).Value)
@@ -170,7 +169,6 @@ func Test_Emote_Remove_Event_Is_Added_To_Event_Store_When_Emote_No_Longer_Exists
 
 	require.Equal("GLOBAL", emoteRemovedEvent["aggregateId"].(*types.AttributeValueMemberS).Value)
 	require.Equal("1", emoteRemovedEvent["emoteId"].(*types.AttributeValueMemberS).Value)
-	require.Equal("GLOBAL#SEQUENCE#0000002", emoteRemovedEvent["eventId"].(*types.AttributeValueMemberS).Value)
 	require.Equal("EmoteRemoved", emoteRemovedEvent["eventName"].(*types.AttributeValueMemberS).Value)
 	require.Equal("EVENT", emoteRemovedEvent["kind"].(*types.AttributeValueMemberS).Value)
 	require.Equal("2", emoteRemovedEvent["sequence"].(*types.AttributeValueMemberN).Value)


### PR DESCRIPTION
## Summary
- Drop `eventId` field from `EmoteServiceEvent` and `createEmoteEvent`; duplicates `pk#sk` already on item and unread.
- Update integration tests to stop asserting `eventId`.

## Test plan
- [x] `task lint`
- [ ] Integration tests pass in CI