### PR TITLE
chore: bump Node to 26.x

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 "aqua:go-task/task" = "3.50.0"
 bun = "1.3.13"
 go = "1.26.2"
-node = "20.20.2"
+node = "26.1.0"
 "npm:@typespec/compiler" = "1.11.0"
 pulumi = "3.232.0"
 turbo = "2.9.6"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "husky": "9.1.7"
   },
   "engines": {
-    "node": "20.x"
+    "node": "26.x"
   },
   "packageManager": "bun@1.3.13",
   "workspaces": [


### PR DESCRIPTION
## Summary
- Bump Node from 20.20.2 to 26.1.0 in `mise.toml`
- Update `engines.node` to `26.x` in root `package.json`

## Test plan
- [ ] `mise install` resolves Node 26.1.0
- [ ] `bun install` succeeds under Node 26
- [ ] `turbo run lint` passes
- [ ] `turbo run build` passes
- [ ] CI green