### PR TITLE
feat: instrument emotes-service with New Relic

### DIFF
--- a/apps/emotes-service/Taskfile.yml
+++ b/apps/emotes-service/Taskfile.yml
@@ -20,6 +20,7 @@ tasks:
         fi
       - pulumi config env add emotes-service/dev --yes
       - pulumi config env add emotes-service/twitch-credentials --yes
+      - pulumi config env add new-relic/dev --yes
 
   create:staging:
     desc: Creates the staging stack in pulumi with ESC values
@@ -32,6 +33,7 @@ tasks:
         fi
       - pulumi config env add emotes-service/staging --yes
       - pulumi config env add emotes-service/twitch-credentials --yes
+      - pulumi config env add new-relic/staging --yes
 
   create:prod:
     desc: Creates the prod stack in pulumi with ESC values
@@ -44,6 +46,7 @@ tasks:
         fi
       - pulumi config env add emotes-service/prod --yes
       - pulumi config env add emotes-service/twitch-credentials --yes
+      - pulumi config env add new-relic/prod --yes
 
   preview:
     desc: Preview any stack changes

--- a/apps/emotes-service/go.mod
+++ b/apps/emotes-service/go.mod
@@ -7,9 +7,12 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.38
+	github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.2
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.5
+	github.com/newrelic/go-agent/v3 v3.43.3
+	github.com/newrelic/go-agent/v3/integrations/nrlambda v1.2.6
 	github.com/pulumi/pulumi-aws/sdk/v7 v7.27.0
 	github.com/pulumi/pulumi-pulumiservice/sdk v0.39.0
 	github.com/pulumi/pulumi/sdk/v3 v3.232.0
@@ -31,7 +34,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23 // indirect
-	github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.22 // indirect
@@ -91,8 +93,6 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
-	github.com/newrelic/go-agent/v3 v3.43.3 // indirect
-	github.com/newrelic/go-agent/v3/integrations/nrlambda v1.2.6 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pgavlin/fx v0.1.6 // indirect

--- a/apps/emotes-service/go.mod
+++ b/apps/emotes-service/go.mod
@@ -91,6 +91,8 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
+	github.com/newrelic/go-agent/v3 v3.43.3 // indirect
+	github.com/newrelic/go-agent/v3/integrations/nrlambda v1.2.6 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pgavlin/fx v0.1.6 // indirect

--- a/apps/emotes-service/go.sum
+++ b/apps/emotes-service/go.sum
@@ -21,8 +21,6 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
 github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
-github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
-github.com/aws/aws-sdk-go-v2 v1.41.6/go.mod h1:dy0UzBIfwSeot4grGvY1AqFWN5zgziMmWGzysDnHFcQ=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9 h1:adBsCIIpLbLmYnkQU+nAChU5yhVTvu5PerROm+/Kq2A=
@@ -35,12 +33,8 @@ github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.38 h1:USC/55d
 github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.38/go.mod h1:oDBKuXwPGNj5nQsgVB4AQmMHTgTLszst5mFIezNwiTg=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 h1:IOGsJ1xVWhsi+ZO7/NW8OuZZBtMJLZbk4P5HDjJO0jQ=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22/go.mod h1:b+hYdbU+jGKfXE8kKM6g1+h+L/Go3vMvzlxBsiuGsxg=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 h1:GmLa5Kw1ESqtFpXsx5MmC84QWa/ZrLZvlJGa2y+4kcQ=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22/go.mod h1:6sW9iWm9DK9YRpRGga/qzrzNLgKpT2cIxb7Vo2eNOp0=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 h1:dY4kWZiSaXIzxnKlj17nHnBcXXBfac6UlsAx2qL6XrU=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22/go.mod h1:KIpEUx0JuRZLO7U6cbV204cWAEco2iC3l061IxlwLtI=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23 h1:FPXsW9+gMuIeKmz7j6ENWcWtBGTe1kH8r9thNt5Uxx4=

--- a/apps/emotes-service/go.sum
+++ b/apps/emotes-service/go.sum
@@ -208,6 +208,10 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
+github.com/newrelic/go-agent/v3 v3.43.3 h1:0A6DkUBYK2bidV6jJDJ1SD2XkRlg976nl+SiEqkGTUQ=
+github.com/newrelic/go-agent/v3 v3.43.3/go.mod h1:MFXnCId5xXMIJI6A/kbkg0DO48EVTsKcmNijMYphzTg=
+github.com/newrelic/go-agent/v3/integrations/nrlambda v1.2.6 h1:c9gyau0c5obrS0Q0NUQsSDrsne40YHn3mInU0Yc3nFU=
+github.com/newrelic/go-agent/v3/integrations/nrlambda v1.2.6/go.mod h1:lXt4snkbSLp6drQB4Jk+tltBTNQBdVQesjk1qYDcvKM=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
 github.com/opentracing/basictracer-go v1.1.0 h1:Oa1fTSBvAl8pa3U+IJYqrKm0NALwH9OsgwOqDv4xJW0=

--- a/apps/emotes-service/infra/components/shared/lambda.go
+++ b/apps/emotes-service/infra/components/shared/lambda.go
@@ -135,11 +135,17 @@ func NewLambda(ctx *pulumi.Context, name string, args *LambdaArgs, opts ...pulum
 		logLevel = "DEBUG"
 	}
 
+	newRelicEnabled := "true"
+	if stack.IsEphemeral(ctx.Stack()) {
+		newRelicEnabled = "false"
+	}
+
 	envVars := pulumi.StringMap{
 		"AWS_LAMBDA_LOG_FORMAT":                    pulumi.String("JSON"),
 		"AWS_LAMBDA_LOG_LEVEL":                     pulumi.String(logLevel),
 		"NEW_RELIC_ACCOUNT_ID":                     pulumi.StringInput(newRelicAccountId),
-		"NEW_RELIC_APM_LAMBDA_MODE":                pulumi.String("true"),
+		"NEW_RELIC_APM_LAMBDA_MODE":                pulumi.String(newRelicEnabled),
+		"NEW_RELIC_DISTRIBUTED_TRACING_ENABLED":    pulumi.String(newRelicEnabled),
 		"NEW_RELIC_APP_NAME":                       pulumi.String(ctx.Project()),
 		"NEW_RELIC_CLOUD_AWS_ACCOUNT_ID":           pulumi.String(awsAccountId),
 		"NEW_RELIC_LICENSE_KEY_SSM_PARAMETER_NAME": pulumi.StringInput(newRelicLambdaLicenseKeySSMParameterArn),

--- a/apps/emotes-service/infra/components/shared/lambda.go
+++ b/apps/emotes-service/infra/components/shared/lambda.go
@@ -4,10 +4,12 @@ import (
 	"emotes-service/infra/stack"
 	"fmt"
 
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws"
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/cloudwatch"
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/iam"
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/lambda"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 type LambdaArgs struct {
@@ -33,8 +35,18 @@ func NewLambda(ctx *pulumi.Context, name string, args *LambdaArgs, opts ...pulum
 		return nil, fmt.Errorf("args.Code is required")
 	}
 
+	caller, err := aws.GetCallerIdentity(ctx, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	awsAccountId := caller.AccountId
+
+	newRelicConfig := config.New(ctx, "newrelic")
+	newRelicAccountId := newRelicConfig.RequireSecret("accountId")
+	newRelicLambdaLicenseKeySSMParameterArn := newRelicConfig.RequireSecret("lambdaLicenseKeySSMParameterArn")
+
 	component := &Lambda{}
-	err := ctx.RegisterComponentResourceV2("components-shared:index:Lambda", name, nil, component, opts...)
+	err = ctx.RegisterComponentResourceV2("components-shared:index:Lambda", name, nil, component, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -81,6 +93,15 @@ func NewLambda(ctx *pulumi.Context, name string, args *LambdaArgs, opts ...pulum
 				pulumi.Sprintf("%s:*", lambdaLogGroup.Arn),
 			},
 		},
+		&iam.GetPolicyDocumentStatementArgs{
+			Effect: pulumi.String("Allow"),
+			Actions: pulumi.StringArray{
+				pulumi.String("ssm:GetParameter"),
+			},
+			Resources: pulumi.StringArray{
+				newRelicLambdaLicenseKeySSMParameterArn,
+			},
+		},
 	}
 	policyStatements = append(policyStatements, args.PolicyStatements...)
 
@@ -115,8 +136,18 @@ func NewLambda(ctx *pulumi.Context, name string, args *LambdaArgs, opts ...pulum
 	}
 
 	envVars := pulumi.StringMap{
-		"AWS_LAMBDA_LOG_FORMAT": pulumi.String("JSON"),
-		"AWS_LAMBDA_LOG_LEVEL":  pulumi.String(logLevel),
+		"AWS_LAMBDA_LOG_FORMAT":                    pulumi.String("JSON"),
+		"AWS_LAMBDA_LOG_LEVEL":                     pulumi.String(logLevel),
+		"NEW_RELIC_ACCOUNT_ID":                     pulumi.StringInput(newRelicAccountId),
+		"NEW_RELIC_APM_LAMBDA_MODE":                pulumi.String("true"),
+		"NEW_RELIC_APP_NAME":                       pulumi.String(ctx.Project()),
+		"NEW_RELIC_CLOUD_AWS_ACCOUNT_ID":           pulumi.String(awsAccountId),
+		"NEW_RELIC_LICENSE_KEY_SSM_PARAMETER_NAME": pulumi.StringInput(newRelicLambdaLicenseKeySSMParameterArn),
+		"NEW_RELIC_LOG_LEVEL":                      pulumi.String(logLevel),
+		"NEW_RELIC_EXTENSION_SEND_LOGS":            pulumi.String("function"),
+		"NEW_RELIC_TRUSTED_ACCOUNT_KEY":            pulumi.StringInput(newRelicAccountId),
+		"STACK":                                    pulumi.String(ctx.Stack()),
+		"PROJECT":                                  pulumi.String(ctx.Project()),
 	}
 	for k, v := range args.Environment {
 		envVars[k] = v
@@ -136,6 +167,9 @@ func NewLambda(ctx *pulumi.Context, name string, args *LambdaArgs, opts ...pulum
 		},
 		Architectures: pulumi.StringArray{
 			pulumi.String("arm64"),
+		},
+		Layers: pulumi.StringArray{
+			pulumi.String("arn:aws:lambda:eu-west-1:451483290750:layer:NewRelicLambdaExtensionARM64:54"),
 		},
 		LoggingConfig: &lambda.FunctionLoggingConfigArgs{
 			ApplicationLogLevel: pulumi.String(logLevel),

--- a/apps/emotes-service/src/adapters/primary/emotes-read-model-producer/main.go
+++ b/apps/emotes-service/src/adapters/primary/emotes-read-model-producer/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
 	if nil != err {
-		slog.Error("error creating app (invalid config)", err)
+		slog.Error("error creating app (invalid config)", "error", err)
 	}
 
 	nrlambda.Start(handler, app)

--- a/apps/emotes-service/src/adapters/primary/emotes-read-model-producer/main.go
+++ b/apps/emotes-service/src/adapters/primary/emotes-read-model-producer/main.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"emotes-service/src/adapters/secondary/event_store"
 	"emotes-service/src/dynamodbstream"
+	"emotes-service/src/environment"
 	readmodelproducer "emotes-service/src/use-cases/emotes-read-model-producer"
 	"log/slog"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-lambda-go/lambdacontext"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/newrelic/go-agent/v3/integrations/nrlambda"
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 func handler(ctx context.Context, event events.DynamoDBEvent) error {
@@ -30,6 +32,18 @@ func handler(ctx context.Context, event events.DynamoDBEvent) error {
 }
 
 func main() {
-	slog.SetDefault(lambdacontext.NewLogger())
-	lambda.Start(handler)
+	logger := lambdacontext.NewLogger().With(
+		slog.Group("tags",
+			"project", environment.GetOrFatal("PROJECT"),
+			"stack", environment.GetOrFatal("STACK"),
+		),
+	)
+	slog.SetDefault(logger)
+
+	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	if nil != err {
+		slog.Error("error creating app (invalid config)", err)
+	}
+
+	nrlambda.Start(handler, app)
 }

--- a/apps/emotes-service/src/adapters/primary/get-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-emotes/main.go
@@ -52,7 +52,7 @@ func main() {
 	slog.SetDefault(logger)
 	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
 	if nil != err {
-		slog.Error("error creating app (invalid config)", err)
+		slog.Error("error creating app (invalid config)", "error", err)
 	}
 
 	nrlambda.Start(handler, app)

--- a/apps/emotes-service/src/adapters/primary/get-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-emotes/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	"emotes-service/src/apigw"
+	"emotes-service/src/environment"
 	getemotes "emotes-service/src/use-cases/get-emotes"
 	"log/slog"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-lambda-go/lambdacontext"
+	"github.com/newrelic/go-agent/v3/integrations/nrlambda"
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 type activeEmoteDTO struct {
@@ -41,6 +43,17 @@ func handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 }
 
 func main() {
-	slog.SetDefault(lambdacontext.NewLogger())
-	lambda.Start(handler)
+	logger := lambdacontext.NewLogger().With(
+		slog.Group("tags",
+			"project", environment.GetOrFatal("PROJECT"),
+			"stack", environment.GetOrFatal("STACK"),
+		),
+	)
+	slog.SetDefault(logger)
+	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	if nil != err {
+		slog.Error("error creating app (invalid config)", err)
+	}
+
+	nrlambda.Start(handler, app)
 }

--- a/apps/emotes-service/src/adapters/primary/get-removed-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-removed-emotes/main.go
@@ -52,7 +52,7 @@ func main() {
 	slog.SetDefault(logger)
 	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
 	if nil != err {
-		slog.Error("error creating app (invalid config)", err)
+		slog.Error("error creating app (invalid config)", "error", err)
 	}
 
 	nrlambda.Start(handler, app)

--- a/apps/emotes-service/src/adapters/primary/get-removed-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-removed-emotes/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	"emotes-service/src/apigw"
+	"emotes-service/src/environment"
 	getremovedemotes "emotes-service/src/use-cases/get-removed-emotes"
 	"log/slog"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-lambda-go/lambdacontext"
+	"github.com/newrelic/go-agent/v3/integrations/nrlambda"
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 type removedEmoteDTO struct {
@@ -41,6 +43,17 @@ func handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 }
 
 func main() {
-	slog.SetDefault(lambdacontext.NewLogger())
-	lambda.Start(handler)
+	logger := lambdacontext.NewLogger().With(
+		slog.Group("tags",
+			"project", environment.GetOrFatal("PROJECT"),
+			"stack", environment.GetOrFatal("STACK"),
+		),
+	)
+	slog.SetDefault(logger)
+	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	if nil != err {
+		slog.Error("error creating app (invalid config)", err)
+	}
+
+	nrlambda.Start(handler, app)
 }

--- a/apps/emotes-service/src/adapters/primary/mock-twitch-api/main.go
+++ b/apps/emotes-service/src/adapters/primary/mock-twitch-api/main.go
@@ -38,7 +38,7 @@ func main() {
 	slog.SetDefault(logger)
 	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
 	if nil != err {
-		slog.Error("error creating app (invalid config)", err)
+		slog.Error("error creating app (invalid config)", "error", err)
 	}
 
 	nrlambda.Start(handler, app)

--- a/apps/emotes-service/src/adapters/primary/mock-twitch-api/main.go
+++ b/apps/emotes-service/src/adapters/primary/mock-twitch-api/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"emotes-service/src/environment"
 	mocktwitchapi "emotes-service/src/use-cases/mock-twitch-api"
 	"log/slog"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-lambda-go/lambdacontext"
+	"github.com/newrelic/go-agent/v3/integrations/nrlambda"
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 func handler(ctx context.Context, event events.LambdaFunctionURLRequest) (events.LambdaFunctionURLResponse, error) {
@@ -27,6 +29,17 @@ func handler(ctx context.Context, event events.LambdaFunctionURLRequest) (events
 }
 
 func main() {
-	slog.SetDefault(lambdacontext.NewLogger())
-	lambda.Start(handler)
+	logger := lambdacontext.NewLogger().With(
+		slog.Group("tags",
+			"project", environment.GetOrFatal("PROJECT"),
+			"stack", environment.GetOrFatal("STACK"),
+		),
+	)
+	slog.SetDefault(logger)
+	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	if nil != err {
+		slog.Error("error creating app (invalid config)", err)
+	}
+
+	nrlambda.Start(handler, app)
 }

--- a/apps/emotes-service/src/adapters/primary/sync-global-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/sync-global-emotes/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"emotes-service/src/environment"
 	syncglobalemotes "emotes-service/src/use-cases/sync-global-emotes"
 	"log/slog"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-lambda-go/lambdacontext"
+	"github.com/newrelic/go-agent/v3/integrations/nrlambda"
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 func handler(ctx context.Context, event events.CloudWatchEvent) error {
@@ -16,6 +18,18 @@ func handler(ctx context.Context, event events.CloudWatchEvent) error {
 }
 
 func main() {
-	slog.SetDefault(lambdacontext.NewLogger())
-	lambda.Start(handler)
+	logger := lambdacontext.NewLogger().With(
+		slog.Group("tags",
+			"project", environment.GetOrFatal("PROJECT"),
+			"stack", environment.GetOrFatal("STACK"),
+		),
+	)
+	slog.SetDefault(logger)
+
+	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	if err != nil {
+		slog.Error("error creating app (invalid config)", "err", err)
+	}
+
+	nrlambda.Start(handler, app)
 }

--- a/apps/emotes-service/src/adapters/secondary/event_store/event_store.go
+++ b/apps/emotes-service/src/adapters/secondary/event_store/event_store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 var client *dynamodb.Client
@@ -54,8 +55,11 @@ type EmoteServiceEvent struct {
 }
 
 func LoadEvents(ctx context.Context, aggregateId string) ([]EmoteServiceEvent, error) {
+	txn := newrelic.FromContext(ctx)
+	tableName := environment.GetOrFatal("TWITCH_EMOTES_EVENT_STORE_TABLE")
+
 	paginator := dynamodb.NewQueryPaginator(client, &dynamodb.QueryInput{
-		TableName:              aws.String(environment.GetOrFatal("TWITCH_EMOTES_EVENT_STORE_TABLE")),
+		TableName:              aws.String(tableName),
 		KeyConditionExpression: aws.String("PK = :pk AND begins_with(SK, :sk)"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{
 			":pk": &types.AttributeValueMemberS{Value: aggregateId},
@@ -66,7 +70,19 @@ func LoadEvents(ctx context.Context, aggregateId string) ([]EmoteServiceEvent, e
 
 	var items []EmoteServiceEvent
 	for paginator.HasMorePages() {
+		ddbSeg := newrelic.DatastoreSegment{
+			StartTime:          txn.StartSegmentNow(),
+			Product:            newrelic.DatastoreDynamoDB,
+			Collection:         tableName,
+			Operation:          "Query",
+			ParameterizedQuery: "PK = :pk AND begins_with(SK, :sk)",
+			QueryParameters: map[string]any{
+				":pk": aggregateId,
+				":sk": "SEQUENCE#",
+			},
+		}
 		page, err := paginator.NextPage(ctx)
+		ddbSeg.End()
 		if err != nil {
 			slog.Error("Error querying", "aggregateId", aggregateId, "error", err)
 			return nil, err
@@ -92,6 +108,7 @@ func AppendEvents(ctx context.Context, events []EmoteServiceEvent) error {
 
 	slog.InfoContext(ctx, "Events to append", "length", eventsLength)
 
+	txn := newrelic.FromContext(ctx)
 	table := environment.GetOrFatal("TWITCH_EMOTES_EVENT_STORE_TABLE")
 
 	const transactWriteMaxItems = 100
@@ -115,9 +132,16 @@ func AppendEvents(ctx context.Context, events []EmoteServiceEvent) error {
 			})
 		}
 
+		ddbSeg := newrelic.DatastoreSegment{
+			StartTime:  txn.StartSegmentNow(),
+			Product:    newrelic.DatastoreDynamoDB,
+			Collection: table,
+			Operation:  "TransactWriteItems",
+		}
 		_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
 			TransactItems: items,
 		})
+		ddbSeg.End()
 
 		if err != nil {
 			slog.ErrorContext(ctx, "AppendEvents failed",

--- a/apps/emotes-service/src/adapters/secondary/twitch/twitch.go
+++ b/apps/emotes-service/src/adapters/secondary/twitch/twitch.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -32,7 +34,11 @@ func GetAccessToken(ctx context.Context) (string, error) {
 		TokenURL:     environment.GetOrFatal("TWITCH_OAUTH_ENDPOINT"),
 	}
 
-	token, err := oauth2Config.Token(context.Background())
+	tokenCtx := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
+		Timeout:   time.Second * 10,
+		Transport: newrelic.NewRoundTripper(nil),
+	})
+	token, err := oauth2Config.Token(tokenCtx)
 	if err != nil {
 		slog.Error("Error getting access token", "error", err)
 		return "", err
@@ -61,10 +67,11 @@ type GlobalEmotesResponse struct {
 
 func GetGlobalEmotes(ctx context.Context, accessToken string) ([]GlobalEmote, error) {
 	client := &http.Client{
-		Timeout: time.Second * 10,
+		Timeout:   time.Second * 10,
+		Transport: newrelic.NewRoundTripper(nil),
 	}
 
-	req, err := http.NewRequest("GET", environment.GetOrFatal("TWITCH_GLOBAL_EMOTES_ENDPOINT"), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", environment.GetOrFatal("TWITCH_GLOBAL_EMOTES_ENDPOINT"), nil)
 	if err != nil {
 		slog.Error("Error creating global emotes request", "error", err)
 		return nil, err

--- a/apps/emotes-service/src/use-cases/sync-global-emotes/sync_global_emotes.go
+++ b/apps/emotes-service/src/use-cases/sync-global-emotes/sync_global_emotes.go
@@ -10,6 +10,8 @@ import (
 	"log"
 	"sort"
 	"time"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 type EmotesAggregate struct {
@@ -136,22 +138,38 @@ func generateId() string {
 }
 
 func Execute(ctx context.Context) error {
+	txn := newrelic.FromContext(ctx)
+
+	seg := txn.StartSegment("twitch.GetAccessToken")
 	token, err := twitch.GetAccessToken(ctx)
+	seg.End()
 	if err != nil {
 		return err
 	}
 
+	seg = txn.StartSegment("twitch.GetGlobalEmotes")
 	emotes, err := twitch.GetGlobalEmotes(ctx, token)
+	seg.End()
 	if err != nil {
 		return err
 	}
 
+	seg = txn.StartSegment("event_store.LoadEvents")
 	events, err := event_store.LoadEvents(ctx, event_store.GlobalEmotesAggregateId)
+	seg.End()
 	if err != nil {
 		return err
 	}
 
+	seg = txn.StartSegment("Aggregate")
 	aggregate := Aggregate(events)
+	seg.End()
+
+	seg = txn.StartSegment("DecideSyncEvents")
 	newEvents := DecideSyncEvents(event_store.GlobalEmotesAggregateId, aggregate, emotes)
+	seg.End()
+
+	seg = txn.StartSegment("event_store.AppendEvents")
+	defer seg.End()
 	return event_store.AppendEvents(ctx, newEvents)
 }


### PR DESCRIPTION
## Summary
- Provision New Relic on the shared lambda component and gate it off for ephemeral stacks
- Instrument emotes-service lambdas with the New Relic Go agent via `nrlambda`
- Trace the `sync-global-emotes` flow with per-step segments, NR HTTP round tripper for Twitch + oauth2, and DynamoDB datastore segments around the event store

## Test plan
- [ ] Deploy to staging and confirm transactions, external segments, and DynamoDB segments appear in New Relic
- [ ] Deploy an ephemeral stack and confirm no telemetry is shipped
- [ ] Trigger sync-global-emotes manually and inspect the trace breakdown