### PR TITLE
feat(emotes-service): instrument remaining adapters

### DIFF
--- a/apps/emotes-service/src/adapters/secondary/mock_store/mock_store.go
+++ b/apps/emotes-service/src/adapters/secondary/mock_store/mock_store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 var client *dynamodb.Client
@@ -25,12 +26,20 @@ func init() {
 func Lookup(ctx context.Context, path string) (string, error) {
 	tableName := environment.GetOrFatal("MOCK_RESPONSES_TABLE")
 
+	txn := newrelic.FromContext(ctx)
+	ddbSeg := newrelic.DatastoreSegment{
+		StartTime:  txn.StartSegmentNow(),
+		Product:    newrelic.DatastoreDynamoDB,
+		Collection: tableName,
+		Operation:  "GetItem",
+	}
 	result, err := client.GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: aws.String(tableName),
 		Key: map[string]types.AttributeValue{
 			"PK": &types.AttributeValueMemberS{Value: path},
 		},
 	})
+	ddbSeg.End()
 	if err != nil {
 		slog.ErrorContext(ctx, "Error reading mock response", "path", path, "error", err)
 		return "", err

--- a/apps/emotes-service/src/adapters/secondary/projections_store/mutation.go
+++ b/apps/emotes-service/src/adapters/secondary/projections_store/mutation.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 var client *dynamodb.Client
@@ -148,7 +149,15 @@ func Persist(ctx context.Context, emoteEvent event_store.EmoteServiceEvent) erro
 		return err
 	}
 
+	txn := newrelic.FromContext(ctx)
+	ddbSeg := newrelic.DatastoreSegment{
+		StartTime:  txn.StartSegmentNow(),
+		Product:    newrelic.DatastoreDynamoDB,
+		Collection: aws.ToString(update.TableName),
+		Operation:  "UpdateItem",
+	}
 	_, err = client.UpdateItem(ctx, update)
+	ddbSeg.End()
 	if err != nil {
 		if _, ok := errors.AsType[*types.ConditionalCheckFailedException](err); ok {
 			slog.InfoContext(ctx, "idempotent skip",

--- a/apps/emotes-service/src/adapters/secondary/projections_store/query.go
+++ b/apps/emotes-service/src/adapters/secondary/projections_store/query.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 func QueryActiveEmotes(ctx context.Context, aggregateId string) ([]ProjectionItem, error) {
@@ -20,8 +21,11 @@ func QueryRemovedEmotes(ctx context.Context, aggregateId string) ([]ProjectionIt
 }
 
 func queryEmotesByStatus(ctx context.Context, aggregateId, status string) ([]ProjectionItem, error) {
+	txn := newrelic.FromContext(ctx)
+	tableName := environment.GetOrFatal("EVENTS_PROJECTION_TABLE_NAME")
+
 	paginator := dynamodb.NewQueryPaginator(client, &dynamodb.QueryInput{
-		TableName:              aws.String(environment.GetOrFatal("EVENTS_PROJECTION_TABLE_NAME")),
+		TableName:              aws.String(tableName),
 		KeyConditionExpression: aws.String("PK = :pk AND begins_with(SK, :sk)"),
 		FilterExpression:       aws.String("#status = :status"),
 		ExpressionAttributeNames: map[string]string{
@@ -36,7 +40,20 @@ func queryEmotesByStatus(ctx context.Context, aggregateId, status string) ([]Pro
 
 	var items []ProjectionItem
 	for paginator.HasMorePages() {
+		ddbSeg := newrelic.DatastoreSegment{
+			StartTime:          txn.StartSegmentNow(),
+			Product:            newrelic.DatastoreDynamoDB,
+			Collection:         tableName,
+			Operation:          "Query",
+			ParameterizedQuery: "PK = :pk AND begins_with(SK, :sk)",
+			QueryParameters: map[string]any{
+				":pk":     aggregateId,
+				":sk":     "EMOTE#",
+				":status": status,
+			},
+		}
 		page, err := paginator.NextPage(ctx)
+		ddbSeg.End()
 		if err != nil {
 			slog.ErrorContext(ctx, "Error querying projections", "aggregateId", aggregateId, "status", status, "error", err)
 			return nil, err

--- a/apps/emotes-service/src/use-cases/emotes-read-model-producer/produce.go
+++ b/apps/emotes-service/src/use-cases/emotes-read-model-producer/produce.go
@@ -4,9 +4,15 @@ import (
 	"context"
 	"emotes-service/src/adapters/secondary/event_store"
 	"emotes-service/src/adapters/secondary/projections_store"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 func Execute(ctx context.Context, events []event_store.EmoteServiceEvent) error {
+	txn := newrelic.FromContext(ctx)
+
+	seg := txn.StartSegment("projections_store.Persist")
+	defer seg.End()
 	for _, event := range events {
 		if err := projections_store.Persist(ctx, event); err != nil {
 			return err

--- a/apps/emotes-service/src/use-cases/get-emotes/get_emotes.go
+++ b/apps/emotes-service/src/use-cases/get-emotes/get_emotes.go
@@ -5,6 +5,8 @@ import (
 	"emotes-service/src/adapters/secondary/event_store"
 	"emotes-service/src/adapters/secondary/projections_store"
 	"log/slog"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 type ActiveEmote struct {
@@ -13,7 +15,11 @@ type ActiveEmote struct {
 }
 
 func ActiveEmotes(ctx context.Context, channelId string) ([]ActiveEmote, error) {
+	txn := newrelic.FromContext(ctx)
+
+	seg := txn.StartSegment("projections_store.QueryActiveEmotes")
 	items, err := projections_store.QueryActiveEmotes(ctx, channelId)
+	seg.End()
 	if err != nil {
 		slog.ErrorContext(ctx, "QueryActiveEmotes failed", "channelId", channelId, "error", err)
 		return nil, err

--- a/apps/emotes-service/src/use-cases/get-removed-emotes/get_removed_emotes.go
+++ b/apps/emotes-service/src/use-cases/get-removed-emotes/get_removed_emotes.go
@@ -5,6 +5,8 @@ import (
 	"emotes-service/src/adapters/secondary/event_store"
 	"emotes-service/src/adapters/secondary/projections_store"
 	"log/slog"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 type RemovedEmote struct {
@@ -13,7 +15,11 @@ type RemovedEmote struct {
 }
 
 func RemovedEmotes(ctx context.Context, channelId string) ([]RemovedEmote, error) {
+	txn := newrelic.FromContext(ctx)
+
+	seg := txn.StartSegment("projections_store.QueryRemovedEmotes")
 	items, err := projections_store.QueryRemovedEmotes(ctx, channelId)
+	seg.End()
 	if err != nil {
 		slog.ErrorContext(ctx, "QueryRemovedEmotes failed", "channelId", channelId, "error", err)
 		return nil, err

--- a/apps/emotes-service/src/use-cases/mock-twitch-api/lookup.go
+++ b/apps/emotes-service/src/use-cases/mock-twitch-api/lookup.go
@@ -3,8 +3,14 @@ package mocktwitchapi
 import (
 	"context"
 	"emotes-service/src/adapters/secondary/mock_store"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 func Execute(ctx context.Context, path string) (string, error) {
+	txn := newrelic.FromContext(ctx)
+
+	seg := txn.StartSegment("mock_store.Lookup")
+	defer seg.End()
 	return mock_store.Lookup(ctx, path)
 }


### PR DESCRIPTION
## Summary
- Add `newrelic.DatastoreSegment` around DynamoDB ops in `projections_store` (Query, UpdateItem) and `mock_store` (GetItem)
- Add `txn.StartSegment` in `get-emotes`, `get-removed-emotes`, `mock-twitch-api`, and `emotes-read-model-producer` use-cases
- Brings these flows to parity with the `sync-global-emotes` pattern from #27

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Deploy to staging; confirm New Relic transaction traces show new segments under each handler
- [ ] Confirm Database tab in New Relic shows operations against projections + mock tables