### PR TITLE
feat(emotes-service): normalise 'global' channelId case-insensitively

### DIFF
--- a/apps/emotes-service/src/adapters/primary/get-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-emotes/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"emotes-service/src/adapters/secondary/event_store"
 	"emotes-service/src/apigw"
 	"emotes-service/src/environment"
 	getemotes "emotes-service/src/use-cases/get-emotes"
 	"log/slog"
+	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambdacontext"
@@ -20,6 +22,10 @@ type activeEmoteDTO struct {
 
 func handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	channelId := request.PathParameters["channelId"]
+
+	if strings.EqualFold(channelId, event_store.GlobalEmotesAggregateId) {
+		channelId = event_store.GlobalEmotesAggregateId
+	}
 
 	if channelId == "" {
 		return apigw.JSONResponse(ctx, 400, map[string]string{"message": "channelId is required"})

--- a/apps/emotes-service/src/adapters/primary/get-removed-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-removed-emotes/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"emotes-service/src/adapters/secondary/event_store"
 	"emotes-service/src/apigw"
 	"emotes-service/src/environment"
 	getremovedemotes "emotes-service/src/use-cases/get-removed-emotes"
 	"log/slog"
+	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambdacontext"
@@ -20,6 +22,10 @@ type removedEmoteDTO struct {
 
 func handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	channelId := request.PathParameters["channelId"]
+
+	if strings.EqualFold(channelId, event_store.GlobalEmotesAggregateId) {
+		channelId = event_store.GlobalEmotesAggregateId
+	}
 
 	if channelId == "" {
 		return apigw.JSONResponse(ctx, 400, map[string]string{"message": "channelId is required"})

--- a/apps/emotes-service/src/tests/integration/global_emotes_test.go
+++ b/apps/emotes-service/src/tests/integration/global_emotes_test.go
@@ -208,6 +208,19 @@ func Test_Api_Returns_Active_Emote_For_Channel(t *testing.T) {
 	require.True(testStartTime.Before(addedAt))
 }
 
+func Test_Api_Returns_Active_Emote_For_Lowercase_Global_Channel(t *testing.T) {
+	require := require.New(t)
+
+	body, status, err := getEmotes(ctx, apiInvokeUrl, apiKey, "global")
+	require.NoError(err)
+	require.Equal(http.StatusOK, status)
+
+	var parsed []apiActiveEmote
+	require.NoError(json.Unmarshal(body, &parsed))
+	require.Len(parsed, 1)
+	require.Equal("1", parsed[0].Emote.Id)
+}
+
 func Test_Api_Returns_Forbidden_Without_Api_Key(t *testing.T) {
 	require := require.New(t)
 
@@ -363,6 +376,19 @@ func Test_Api_Returns_Removed_Emote_For_Channel(t *testing.T) {
 	removedAt, err := time.Parse(time.RFC3339Nano, emote.RemovedAt)
 	require.NoError(err)
 	require.True(testStartTime.Before(removedAt))
+}
+
+func Test_Api_Returns_Removed_Emote_For_Lowercase_Global_Channel(t *testing.T) {
+	require := require.New(t)
+
+	body, status, err := getRemovedEmotes(ctx, apiInvokeUrl, apiKey, "global")
+	require.NoError(err)
+	require.Equal(http.StatusOK, status)
+
+	var parsed []apiRemovedEmote
+	require.NoError(json.Unmarshal(body, &parsed))
+	require.Len(parsed, 1)
+	require.Equal("1", parsed[0].Emote.Id)
 }
 
 func loadAwsConfig(t *testing.T) aws.Config {


### PR DESCRIPTION
## Summary
- Map any case variant of `global` (e.g. `global`, `Global`) on the emotes REST API path param to the canonical uppercase `GLOBAL` aggregate ID before DB lookup.
- Applied at the handler layer for both `GET /emotes/{channelId}` and `GET /emotes/{channelId}/removed`.
- Reuses `event_store.GlobalEmotesAggregateId` so the canonical value isn't duplicated.

## Test plan
- [x] `go build ./...` in `apps/emotes-service`
- [x] `go vet ./...` and `go vet -tags=integration ./...`
- [x] Integration tests compile (`-run XXX_NEVER_MATCH -tags=integration`)
- [ ] Integration suite passes against ephemeral stack (requires deployed env): `go test -tags=integration ./src/tests/integration/...`
- [ ] Manual: `curl $API/emotes/global` returns same payload as `curl $API/emotes/GLOBAL`