### PR TITLE
feat(web): add empty states to emotes tabs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,11 @@ jobs:
         run: turbo run deploy:staging --affected
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          EMOTES_SERVICE_API_URL: ${{ secrets.EMOTES_SERVICE_API_URL }}
+          EMOTES_SERVICE_API_KEY: ${{ secrets.EMOTES_SERVICE_API_KEY }}
       - name: Deploy prod
         run: turbo run deploy:prod --affected
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          EMOTES_SERVICE_API_URL: ${{ secrets.EMOTES_SERVICE_API_URL }}
+          EMOTES_SERVICE_API_KEY: ${{ secrets.EMOTES_SERVICE_API_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,6 +36,8 @@ jobs:
         env:
           NEXT_PUBLIC_TWITCH_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_TWITCH_CLIENT_ID }}
           TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
+          EMOTES_SERVICE_API_URL: ${{ secrets.EMOTES_SERVICE_API_URL }}
+          EMOTES_SERVICE_API_KEY: ${{ secrets.EMOTES_SERVICE_API_KEY }}
 
   ci-test:
     runs-on: ubuntu-latest

--- a/apps/web/components/emotes/emote-tabs.tsx
+++ b/apps/web/components/emotes/emote-tabs.tsx
@@ -14,9 +14,9 @@ type Props = {
 const EmoteTabs = ({ activeEmotes, removedEmotes }: Props) => {
   const [tab, setTab] = useState<Tab>('active');
 
-  const tabs: Array<{ id: Tab; label: string; count: number; emotes: (ActiveEmote | RemovedEmote)[] }> = [
-    { id: 'active', label: 'Active', count: activeEmotes.length, emotes: activeEmotes },
-    { id: 'removed', label: 'Removed', count: removedEmotes.length, emotes: removedEmotes },
+  const tabs: Array<{ id: Tab; label: string; count: number; emotes: (ActiveEmote | RemovedEmote)[]; emptyMessage: string }> = [
+    { id: 'active', label: 'Active', count: activeEmotes.length, emotes: activeEmotes, emptyMessage: 'No active emotes' },
+    { id: 'removed', label: 'Removed', count: removedEmotes.length, emotes: removedEmotes, emptyMessage: 'No removed emotes' },
   ];
 
   return (
@@ -36,9 +36,9 @@ const EmoteTabs = ({ activeEmotes, removedEmotes }: Props) => {
           </TabsTrigger>
         ))}
       </TabsList>
-      {tabs.map(({ id, emotes }) => (
+      {tabs.map(({ id, emotes, emptyMessage }) => (
         <TabsContent key={id} value={id}>
-          <EmotesList emotes={emotes} />
+          <EmotesList emotes={emotes} emptyMessage={emptyMessage} />
         </TabsContent>
       ))}
     </Tabs>

--- a/apps/web/components/emotes/emotes-list.tsx
+++ b/apps/web/components/emotes/emotes-list.tsx
@@ -1,6 +1,5 @@
-import { Inbox } from 'lucide-react';
 import { Card } from '~/components/ui/card';
-import { Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '~/components/ui/empty';
+import { Empty, EmptyDescription, EmptyHeader } from '~/components/ui/empty';
 import type { Emote } from '~/lib/api/emotes-service';
 
 type Props = {
@@ -13,9 +12,6 @@ const EmotesList = ({ emotes, emptyMessage = 'No emotes to display' }: Props) =>
     return (
       <Empty className='min-h-[400px] border-none'>
         <EmptyHeader>
-          <EmptyMedia variant='icon'>
-            <Inbox />
-          </EmptyMedia>
           <EmptyDescription>{emptyMessage}</EmptyDescription>
         </EmptyHeader>
       </Empty>

--- a/apps/web/components/emotes/emotes-list.tsx
+++ b/apps/web/components/emotes/emotes-list.tsx
@@ -1,33 +1,51 @@
+import { Inbox } from 'lucide-react';
 import { Card } from '~/components/ui/card';
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '~/components/ui/empty';
 import type { Emote } from '~/lib/api/emotes-service';
 
 type Props = {
   emotes: Array<{ emote: Emote }>;
+  emptyMessage?: string;
 };
 
-const EmotesList = ({ emotes }: Props) => (
-  <ul
-    data-testid='emoteList'
-    className='flex flex-row flex-wrap justify-center gap-6 py-12'
-  >
-    {emotes.map(({ emote }, index) => (
-      <li key={emote.id}>
-        <Card size='sm' className='size-36 items-center justify-center gap-2 p-4'>
-          <div className='relative size-full'>
-            <img
-              alt={`${emote.name} emote`}
-              data-testid={`emoteImage${index}`}
-              src={emote.images.url_4x}
-              className='absolute inset-0 size-full object-contain'
-            />
-          </div>
-          <p className='tracking-wide' data-testid={`emoteName${index}`}>
-            {emote.name}
-          </p>
-        </Card>
-      </li>
-    ))}
-  </ul>
-);
+const EmotesList = ({ emotes, emptyMessage = 'No emotes to display' }: Props) => {
+  if (emotes.length === 0) {
+    return (
+      <Empty className='min-h-[400px] border-none'>
+        <EmptyHeader>
+          <EmptyMedia variant='icon'>
+            <Inbox />
+          </EmptyMedia>
+          <EmptyDescription>{emptyMessage}</EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  return (
+    <ul
+      data-testid='emoteList'
+      className='flex flex-row flex-wrap justify-center gap-6 py-12'
+    >
+      {emotes.map(({ emote }, index) => (
+        <li key={emote.id}>
+          <Card size='sm' className='size-36 items-center justify-center gap-2 p-4'>
+            <div className='relative size-full'>
+              <img
+                alt={`${emote.name} emote`}
+                data-testid={`emoteImage${index}`}
+                src={emote.images.url_4x}
+                className='absolute inset-0 size-full object-contain'
+              />
+            </div>
+            <p className='tracking-wide' data-testid={`emoteName${index}`}>
+              {emote.name}
+            </p>
+          </Card>
+        </li>
+      ))}
+    </ul>
+  );
+};
 
 export default EmotesList;


### PR DESCRIPTION
## Summary

- Add empty state to active and removed emote tabs when no emotes exist
- Uses existing `Empty`/`EmptyHeader`/`EmptyMedia`/`EmptyDescription` shadcn components from `~/components/ui/empty`
- Empty state is vertically and horizontally centred via `min-h-[400px]` flex container (built into `Empty` component)
- Tab-specific messages: "No active emotes" / "No removed emotes"

## Changes

- `apps/web/components/emotes/emotes-list.tsx` — early return with `Empty` component when `emotes.length === 0`; accepts optional `emptyMessage` prop
- `apps/web/components/emotes/emote-tabs.tsx` — passes tab-specific `emptyMessage` to each `EmotesList`

## Reviewer notes

No new dependencies. `Empty` component was already installed in the project.