### PR TITLE
refactor(emotes-service): centralize id generation in ids pkg

### DIFF
--- a/apps/emotes-service/src/adapters/secondary/projections_store/mutation.go
+++ b/apps/emotes-service/src/adapters/secondary/projections_store/mutation.go
@@ -2,10 +2,9 @@ package projections_store
 
 import (
 	"context"
-	"crypto/rand"
 	"emotes-service/src/adapters/secondary/event_store"
 	"emotes-service/src/environment"
-	"encoding/hex"
+	"emotes-service/src/ids"
 	"errors"
 	"fmt"
 	"log"
@@ -93,7 +92,7 @@ func buildProjectionUpdate(ctx context.Context, emoteEvent event_store.EmoteServ
 			},
 			ExpressionAttributeValues: map[string]types.AttributeValue{
 				":active":  &types.AttributeValueMemberS{Value: "ACTIVE"},
-				":id":      &types.AttributeValueMemberS{Value: generateId()},
+				":id":      &types.AttributeValueMemberS{Value: ids.New("es_prj_")},
 				":emoteId": &types.AttributeValueMemberS{Value: emoteEvent.EmoteId},
 				":emote":   emoteAttr,
 				":null":    &types.AttributeValueMemberNULL{Value: true},
@@ -132,15 +131,6 @@ func buildProjectionUpdate(ctx context.Context, emoteEvent event_store.EmoteServ
 
 	slog.ErrorContext(ctx, "Unhandled event", "eventName", emoteEvent.EventName, "event", emoteEvent)
 	return nil, fmt.Errorf("unhandled event: %s", emoteEvent.EventName)
-}
-
-func generateId() string {
-	bytes := make([]byte, 12)
-	_, err := rand.Read(bytes)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return fmt.Sprintf("es_prj_%s", hex.EncodeToString(bytes))
 }
 
 func Persist(ctx context.Context, emoteEvent event_store.EmoteServiceEvent) error {

--- a/apps/emotes-service/src/ids/ids.go
+++ b/apps/emotes-service/src/ids/ids.go
@@ -1,0 +1,17 @@
+package ids
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log"
+)
+
+// New returns a new id formatted as "<prefix><hex>" where hex is 12 random bytes.
+func New(prefix string) string {
+	bytes := make([]byte, 12)
+	if _, err := rand.Read(bytes); err != nil {
+		log.Fatal(err)
+	}
+	return fmt.Sprintf("%s%s", prefix, hex.EncodeToString(bytes))
+}

--- a/apps/emotes-service/src/use-cases/add-channel/channels.go
+++ b/apps/emotes-service/src/use-cases/add-channel/channels.go
@@ -2,13 +2,10 @@ package addchannel
 
 import (
 	"context"
-	"crypto/rand"
 	"emotes-service/src/adapters/secondary/channels_store"
 	"emotes-service/src/adapters/secondary/twitch"
-	"encoding/hex"
+	"emotes-service/src/ids"
 	"errors"
-	"fmt"
-	"log"
 	"log/slog"
 	"strings"
 	"time"
@@ -59,7 +56,7 @@ func AddChannel(ctx context.Context, input Input) (Channel, error) {
 	item := channels_store.ChannelItem{
 		PK:          channels_store.ChannelsPartitionKey,
 		SK:          twitchId,
-		Id:          generateId(),
+		Id:          ids.New("chnl_"),
 		TwitchId:    twitchId,
 		DisplayName: user.DisplayName,
 		ImageUrl:    user.ProfileImageURL,
@@ -85,11 +82,3 @@ func AddChannel(ctx context.Context, input Input) (Channel, error) {
 	}, nil
 }
 
-func generateId() string {
-	bytes := make([]byte, 12)
-	_, err := rand.Read(bytes)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return fmt.Sprintf("chnl_%s", hex.EncodeToString(bytes))
-}

--- a/apps/emotes-service/src/use-cases/add-channel/channels.go
+++ b/apps/emotes-service/src/use-cases/add-channel/channels.go
@@ -81,4 +81,3 @@ func AddChannel(ctx context.Context, input Input) (Channel, error) {
 		UpdatedAt:   item.UpdatedAt,
 	}, nil
 }
-

--- a/apps/emotes-service/src/use-cases/sync-global-emotes/sync_global_emotes.go
+++ b/apps/emotes-service/src/use-cases/sync-global-emotes/sync_global_emotes.go
@@ -2,12 +2,10 @@ package syncglobalemotes
 
 import (
 	"context"
-	"crypto/rand"
 	"emotes-service/src/adapters/secondary/event_store"
 	"emotes-service/src/adapters/secondary/twitch"
-	"encoding/hex"
+	"emotes-service/src/ids"
 	"fmt"
-	"log"
 	"sort"
 	"time"
 
@@ -119,7 +117,7 @@ func createEmoteEvent(in createEmoteEventInput) event_store.EmoteServiceEvent {
 		Emote:       in.Emote,
 		EmoteId:     in.EmoteId,
 		EventName:   in.EventName,
-		Id:          generateId(),
+		Id:          ids.New("es_"),
 		Kind:        "EVENT",
 		Sequence:    in.Sequence,
 	}
@@ -127,14 +125,6 @@ func createEmoteEvent(in createEmoteEventInput) event_store.EmoteServiceEvent {
 
 func generateEventSequence(n int) string {
 	return fmt.Sprintf("%07d", n)
-}
-
-func generateId() string {
-	bytes := make([]byte, 12)
-	if _, err := rand.Read(bytes); err != nil {
-		log.Fatal(err)
-	}
-	return fmt.Sprintf("es_%s", hex.EncodeToString(bytes))
 }
 
 // FetchEmotesFunc fetches the Twitch emotes for a given aggregate. The


### PR DESCRIPTION
## Summary
- New `emotes-service/src/ids` pkg exposes `ids.New(prefix string) string` — single source of id creation.
- Replaces three identical `generateId()` funcs in `projections_store/mutation.go`, `sync-global-emotes/sync_global_emotes.go`, `add-channel/channels.go`.
- Prefixes (`es_prj_`, `es_`, `chnl_`) preserved at call sites; format/length unchanged (12 random bytes hex-encoded).

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
- [x] `grep -rn generateId apps/emotes-service/src` returns nothing