### PR TITLE
feat(web): fetch channels at request time from emotes-service

### DIFF
--- a/apps/web/components/emotes/channel-list.tsx
+++ b/apps/web/components/emotes/channel-list.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { Avatar, AvatarFallback, AvatarImage } from '~/components/ui/avatar';
 import { Card } from '~/components/ui/card';
-import { channelSlug, type Channel } from '~/lib/api/emotes-service';
+import { channelSlug, type Channel } from '~/lib/api/channels';
 
 type Props = {
   channels: Channel[];

--- a/apps/web/components/emotes/channel-list.tsx
+++ b/apps/web/components/emotes/channel-list.tsx
@@ -12,13 +12,13 @@ const ChannelList = ({ channels }: Props) => (
     data-testid='channelList'
     className='grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5'
   >
-    {channels.map(({ id, displayName, profileImageUrl, icon }) => (
+    {channels.map(({ id, displayName, imageUrl, icon }) => (
       <li key={id}>
         <Link href={`/emotes/${id}`} className='group block'>
           <Card className='flex flex-col items-center gap-3 p-5 ring-1 ring-transparent group-hover:ring-primary/60'>
-            {profileImageUrl ? (
+            {imageUrl ? (
               <Avatar className='size-20 sm:size-24'>
-                <AvatarImage src={profileImageUrl} alt={`${displayName} avatar`} />
+                <AvatarImage src={imageUrl} alt={`${displayName} avatar`} />
                 <AvatarFallback>{displayName.slice(0, 2)}</AvatarFallback>
               </Avatar>
             ) : icon ? (

--- a/apps/web/components/emotes/channel-list.tsx
+++ b/apps/web/components/emotes/channel-list.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { Avatar, AvatarFallback, AvatarImage } from '~/components/ui/avatar';
 import { Card } from '~/components/ui/card';
-import type { Channel } from '~/lib/api/emotes-service';
+import { channelSlug, type Channel } from '~/lib/api/emotes-service';
 
 type Props = {
   channels: Channel[];
@@ -12,22 +12,33 @@ const ChannelList = ({ channels }: Props) => (
     data-testid='channelList'
     className='grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5'
   >
-    {channels.map(({ id, displayName, imageUrl, icon }) => (
-      <li key={id}>
-        <Link href={`/emotes/${id}`} className='group block'>
+    {channels.map((channel) => (
+      <li key={channel.id}>
+        <Link
+          href={`/emotes/${channelSlug(channel)}`}
+          className='group block'
+        >
           <Card className='flex flex-col items-center gap-3 p-5 ring-1 ring-transparent group-hover:ring-primary/60'>
-            {imageUrl ? (
+            {channel.type === 'twitch' ? (
               <Avatar className='size-20 sm:size-24'>
-                <AvatarImage src={imageUrl} alt={`${displayName} avatar`} />
-                <AvatarFallback>{displayName.slice(0, 2)}</AvatarFallback>
+                <AvatarImage
+                  src={channel.imageUrl}
+                  alt={`${channel.displayName} avatar`}
+                />
+                <AvatarFallback>
+                  {channel.displayName.slice(0, 2)}
+                </AvatarFallback>
               </Avatar>
-            ) : icon ? (
-              <div className='flex size-20 items-center justify-center text-5xl sm:size-24' aria-hidden>
-                {icon}
+            ) : (
+              <div
+                className='flex size-20 items-center justify-center text-5xl sm:size-24'
+                aria-hidden
+              >
+                {channel.icon}
               </div>
-            ) : null}
+            )}
             <p className='truncate text-base font-semibold text-foreground group-hover:text-primary'>
-              {displayName}
+              {channel.displayName}
             </p>
           </Card>
         </Link>

--- a/apps/web/lib/api/channels.ts
+++ b/apps/web/lib/api/channels.ts
@@ -1,0 +1,26 @@
+export interface GlobalChannel {
+  type: 'global';
+  id: 'global';
+  displayName: string;
+  icon: string;
+}
+
+export interface TwitchChannel {
+  type: 'twitch';
+  id: string;
+  twitchId: string;
+  displayName: string;
+  imageUrl: string;
+}
+
+export type Channel = GlobalChannel | TwitchChannel;
+
+export const channelSlug = (channel: Channel): string =>
+  channel.type === 'global' ? 'global' : channel.twitchId;
+
+export const GLOBAL_CHANNEL: GlobalChannel = {
+  type: 'global',
+  id: 'global',
+  displayName: 'Global',
+  icon: '🌐',
+};

--- a/apps/web/lib/api/emotes-service.ts
+++ b/apps/web/lib/api/emotes-service.ts
@@ -45,23 +45,51 @@ export const getActiveEmotes = (channel: string): Promise<ActiveEmote[]> =>
 export const getRemovedEmotes = (channel: string): Promise<RemovedEmote[]> =>
   fetchEmotes(`${apiUrl}/v1/emotes/${channel}/removed`, 'getRemovedEmotes');
 
-export interface Channel {
-  id: string;
+export interface GlobalChannel {
+  type: 'global';
+  id: 'global';
   displayName: string;
-  imageUrl?: string;
-  icon?: string;
+  icon: string;
 }
 
-const GLOBAL_CHANNEL: Channel = {
+export interface TwitchChannel {
+  type: 'twitch';
+  id: string;
+  twitchId: string;
+  displayName: string;
+  imageUrl: string;
+}
+
+export type Channel = GlobalChannel | TwitchChannel;
+
+export const channelSlug = (channel: Channel): string =>
+  channel.type === 'global' ? 'global' : channel.twitchId;
+
+interface ChannelDto {
+  id: string;
+  twitchId: string;
+  displayName: string;
+  imageUrl: string;
+}
+
+const GLOBAL_CHANNEL: GlobalChannel = {
+  type: 'global',
   id: 'global',
   displayName: 'Global',
   icon: '🌐',
 };
 
 export const getChannels = async (): Promise<Channel[]> => {
-  const channels = await fetchEmotes<Channel[]>(
+  const channels = await fetchEmotes<ChannelDto[]>(
     `${apiUrl}/v1/channels`,
     'getChannels'
   );
-  return [GLOBAL_CHANNEL, ...channels];
+  const twitchChannels: TwitchChannel[] = channels.map((c) => ({
+    type: 'twitch',
+    id: c.id,
+    twitchId: c.twitchId,
+    displayName: c.displayName,
+    imageUrl: c.imageUrl,
+  }));
+  return [GLOBAL_CHANNEL, ...twitchChannels];
 };

--- a/apps/web/lib/api/emotes-service.ts
+++ b/apps/web/lib/api/emotes-service.ts
@@ -1,4 +1,11 @@
 import { getEnvOrThrow } from '~/lib/helpers';
+import {
+  GLOBAL_CHANNEL,
+  type Channel,
+  type TwitchChannel,
+} from '~/lib/api/channels';
+
+export type { Channel } from '~/lib/api/channels';
 
 const apiUrl = getEnvOrThrow('EMOTES_SERVICE_API_URL');
 const apiKey = getEnvOrThrow('EMOTES_SERVICE_API_KEY');
@@ -45,26 +52,6 @@ export const getActiveEmotes = (channel: string): Promise<ActiveEmote[]> =>
 export const getRemovedEmotes = (channel: string): Promise<RemovedEmote[]> =>
   fetchEmotes(`${apiUrl}/v1/emotes/${channel}/removed`, 'getRemovedEmotes');
 
-export interface GlobalChannel {
-  type: 'global';
-  id: 'global';
-  displayName: string;
-  icon: string;
-}
-
-export interface TwitchChannel {
-  type: 'twitch';
-  id: string;
-  twitchId: string;
-  displayName: string;
-  imageUrl: string;
-}
-
-export type Channel = GlobalChannel | TwitchChannel;
-
-export const channelSlug = (channel: Channel): string =>
-  channel.type === 'global' ? 'global' : channel.twitchId;
-
 interface ChannelDto {
   id: string;
   twitchId: string;
@@ -72,18 +59,12 @@ interface ChannelDto {
   imageUrl: string;
 }
 
-const GLOBAL_CHANNEL: GlobalChannel = {
-  type: 'global',
-  id: 'global',
-  displayName: 'Global',
-  icon: '🌐',
-};
-
 export const getChannels = async (): Promise<Channel[]> => {
   const channels = await fetchEmotes<ChannelDto[]>(
     `${apiUrl}/v1/channels`,
     'getChannels'
   );
+
   const twitchChannels: TwitchChannel[] = channels.map((c) => ({
     type: 'twitch',
     id: c.id,

--- a/apps/web/lib/api/emotes-service.ts
+++ b/apps/web/lib/api/emotes-service.ts
@@ -48,19 +48,20 @@ export const getRemovedEmotes = (channel: string): Promise<RemovedEmote[]> =>
 export interface Channel {
   id: string;
   displayName: string;
-  profileImageUrl?: string;
+  imageUrl?: string;
   icon?: string;
 }
 
-// TODO: replace body with `fetch(`${apiUrl}/channels`, { headers: { 'x-api-key': apiKey } })`
-// once the emotes-service exposes a list-channels endpoint.
-export const getChannels = async (): Promise<Channel[]> => [
-  { id: 'global', displayName: 'Global' },
-];
+const GLOBAL_CHANNEL: Channel = {
+  id: 'global',
+  displayName: 'Global',
+  icon: '🌐',
+};
 
-// TODO: replace with real channel list enriched via Twitch Get Users
-// (batch ids, map profile_image_url -> profileImageUrl, broadcaster_type ->
-// broadcasterType). Mock data for prototype only.
-export const getChannelListing = async (): Promise<Channel[]> => [
-  { id: 'global', displayName: 'Global', icon: '🌐' },
-];
+export const getChannels = async (): Promise<Channel[]> => {
+  const channels = await fetchEmotes<Channel[]>(
+    `${apiUrl}/channels`,
+    'getChannels'
+  );
+  return [GLOBAL_CHANNEL, ...channels];
+};

--- a/apps/web/lib/api/emotes-service.ts
+++ b/apps/web/lib/api/emotes-service.ts
@@ -60,7 +60,7 @@ const GLOBAL_CHANNEL: Channel = {
 
 export const getChannels = async (): Promise<Channel[]> => {
   const channels = await fetchEmotes<Channel[]>(
-    `${apiUrl}/channels`,
+    `${apiUrl}/v1/channels`,
     'getChannels'
   );
   return [GLOBAL_CHANNEL, ...channels];

--- a/apps/web/pages/emotes/[channel].tsx
+++ b/apps/web/pages/emotes/[channel].tsx
@@ -3,7 +3,8 @@ import Head from 'next/head';
 import { DynamicLastUpdated, EmoteTabs } from '~/components/emotes';
 import { Heading } from '~/components/shared';
 import {
-  Channel,
+  channelSlug,
+  type Channel,
   getActiveEmotes,
   getChannels,
   getRemovedEmotes,
@@ -19,14 +20,14 @@ export async function getServerSideProps(
     'public, s-maxage=300, stale-while-revalidate'
   );
 
-  const channelId = ctx.params?.channel;
+  const channelParam = ctx.params?.channel;
 
-  if (!channelId) {
+  if (!channelParam) {
     return { notFound: true } as const;
   }
 
   const channels = await getChannels();
-  const channel = channels.find(({ id }) => id === channelId);
+  const channel = channels.find((c) => channelSlug(c) === channelParam);
 
   if (!channel) {
     return { notFound: true } as const;

--- a/apps/web/pages/emotes/[channel].tsx
+++ b/apps/web/pages/emotes/[channel].tsx
@@ -3,12 +3,11 @@ import Head from 'next/head';
 import { DynamicLastUpdated, EmoteTabs } from '~/components/emotes';
 import { Heading } from '~/components/shared';
 import {
-  channelSlug,
-  type Channel,
   getActiveEmotes,
   getChannels,
   getRemovedEmotes,
 } from '~/lib/api/emotes-service';
+import { channelSlug, type Channel } from '~/lib/api/channels';
 
 type Params = { channel: string };
 

--- a/apps/web/pages/emotes/[channel].tsx
+++ b/apps/web/pages/emotes/[channel].tsx
@@ -1,8 +1,4 @@
-import {
-  GetStaticPaths,
-  GetStaticPropsContext,
-  InferGetStaticPropsType,
-} from 'next';
+import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
 import Head from 'next/head';
 import { DynamicLastUpdated, EmoteTabs } from '~/components/emotes';
 import { Heading } from '~/components/shared';
@@ -15,16 +11,14 @@ import {
 
 type Params = { channel: string };
 
-export const getStaticPaths: GetStaticPaths<Params> = async () => {
-  const channels = await getChannels();
+export async function getServerSideProps(
+  ctx: GetServerSidePropsContext<Params>
+) {
+  ctx.res.setHeader(
+    'Cache-Control',
+    'public, s-maxage=300, stale-while-revalidate'
+  );
 
-  return {
-    paths: channels.map(({ id }) => ({ params: { channel: id } })),
-    fallback: 'blocking',
-  };
-};
-
-export async function getStaticProps(ctx: GetStaticPropsContext<Params>) {
   const channelId = ctx.params?.channel;
 
   if (!channelId) {
@@ -50,7 +44,6 @@ export async function getStaticProps(ctx: GetStaticPropsContext<Params>) {
       removedEmotes,
       updatedAt: Date.now(),
     },
-    revalidate: 60 * 60,
   };
 }
 
@@ -59,7 +52,9 @@ const ChannelEmotesPage = ({
   activeEmotes,
   removedEmotes,
   updatedAt,
-}: InferGetStaticPropsType<typeof getStaticProps> & { channel: Channel }) => (
+}: InferGetServerSidePropsType<typeof getServerSideProps> & {
+  channel: Channel;
+}) => (
   <>
     <Head>
       <title>{`${channel.displayName} Emotes | SeriousSloth`}</title>

--- a/apps/web/pages/emotes/[channel].tsx
+++ b/apps/web/pages/emotes/[channel].tsx
@@ -33,8 +33,8 @@ export async function getServerSideProps(
   }
 
   const [activeEmotes, removedEmotes] = await Promise.all([
-    getActiveEmotes(channel.id),
-    getRemovedEmotes(channel.id),
+    getActiveEmotes(channelParam),
+    getRemovedEmotes(channelParam),
   ]);
 
   return {

--- a/apps/web/pages/emotes/index.tsx
+++ b/apps/web/pages/emotes/index.tsx
@@ -1,22 +1,24 @@
-import { InferGetStaticPropsType } from 'next';
+import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
 import Head from 'next/head';
 import { ChannelList } from '~/components/emotes';
 import { Heading } from '~/components/shared';
 import { emotesTitle } from '~/constants/titles';
-import { getChannelListing } from '~/lib/api/emotes-service';
+import { getChannels } from '~/lib/api/emotes-service';
 
-export async function getStaticProps() {
-  const channels = await getChannelListing();
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  ctx.res.setHeader(
+    'Cache-Control',
+    'public, s-maxage=300, stale-while-revalidate'
+  );
 
-  return {
-    props: { channels },
-    revalidate: 60 * 60,
-  };
+  const channels = await getChannels();
+
+  return { props: { channels } };
 }
 
 const EmotesPage = ({
   channels,
-}: InferGetStaticPropsType<typeof getStaticProps>) => (
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => (
   <>
     <Head>
       <title>{emotesTitle}</title>


### PR DESCRIPTION
## Summary

- Switch `/emotes` and `/emotes/[channel]` from build-time `getStaticProps` to `getServerSideProps` with `Cache-Control: public, s-maxage=300, stale-while-revalidate` (5 min CDN cache).
- Replace the hardcoded mock channel list with a real `GET /channels` call to `emotes-service` via the existing `fetchEmotes` helper. The hardcoded `Global` channel is preserved and prepended so it's always first.
- Rename `Channel.profileImageUrl` to `imageUrl` to match the emotes-service response shape; drop the resolved TODOs and the now-redundant `getChannelListing`.

## Test plan

- [ ] `bun run test` in `apps/web` (passes locally — 17/17).
- [ ] `bun x tsc --noEmit` clean.
- [ ] `pnpm dev` (or `bun dev`) → visit `/emotes`; confirm response carries `Cache-Control: public, s-maxage=300, stale-while-revalidate` and `Global` is first.
- [ ] Click into a channel → `/emotes/[id]` renders with same cache header.
- [ ] `/emotes/does-not-exist` returns 404.