### PR TITLE
refactor(web): construct emoteUrl server-side, trim props

### DIFF
--- a/apps/web/components/emotes/emote-tabs.tsx
+++ b/apps/web/components/emotes/emote-tabs.tsx
@@ -1,20 +1,23 @@
 import { useState } from 'react';
 import { Badge } from '~/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
-import type { ActiveEmote, RemovedEmote } from '~/lib/api/emotes-service';
+import type {
+  ActiveEmoteEntry,
+  RemovedEmoteEntry,
+} from '~/lib/api/emotes-service';
 import EmotesList from './emotes-list';
 
 type Tab = 'active' | 'removed';
 
 type Props = {
-  activeEmotes: ActiveEmote[];
-  removedEmotes: RemovedEmote[];
+  activeEmotes: ActiveEmoteEntry[];
+  removedEmotes: RemovedEmoteEntry[];
 };
 
 const EmoteTabs = ({ activeEmotes, removedEmotes }: Props) => {
   const [tab, setTab] = useState<Tab>('active');
 
-  const tabs: Array<{ id: Tab; label: string; count: number; emotes: (ActiveEmote | RemovedEmote)[]; emptyMessage: string }> = [
+  const tabs: Array<{ id: Tab; label: string; count: number; emotes: (ActiveEmoteEntry | RemovedEmoteEntry)[]; emptyMessage: string }> = [
     { id: 'active', label: 'Active', count: activeEmotes.length, emotes: activeEmotes, emptyMessage: 'No active emotes' },
     { id: 'removed', label: 'Removed', count: removedEmotes.length, emotes: removedEmotes, emptyMessage: 'No removed emotes' },
   ];

--- a/apps/web/components/emotes/emotes-list.tsx
+++ b/apps/web/components/emotes/emotes-list.tsx
@@ -1,9 +1,9 @@
 import { Card } from '~/components/ui/card';
 import { Empty, EmptyDescription, EmptyHeader } from '~/components/ui/empty';
-import type { Emote } from '~/lib/api/emotes-service';
+import type { EmoteListEntry } from '~/lib/api/emotes-service';
 
 type Props = {
-  emotes: Array<{ emote: Emote }>;
+  emotes: EmoteListEntry[];
   emptyMessage?: string;
 };
 
@@ -23,14 +23,14 @@ const EmotesList = ({ emotes, emptyMessage = 'No emotes to display' }: Props) =>
       data-testid='emoteList'
       className='flex flex-row flex-wrap justify-center gap-6 py-12'
     >
-      {emotes.map(({ emote }, index) => (
+      {emotes.map((emote, index) => (
         <li key={emote.id}>
           <Card size='sm' className='size-36 items-center justify-center gap-2 p-4'>
             <div className='relative size-full'>
               <img
                 alt={`${emote.name} emote`}
                 data-testid={`emoteImage${index}`}
-                src={emote.images.url_4x}
+                src={emote.emoteUrl}
                 className='absolute inset-0 size-full object-contain'
               />
             </div>

--- a/apps/web/lib/api/emotes-service.ts
+++ b/apps/web/lib/api/emotes-service.ts
@@ -33,6 +33,20 @@ export interface RemovedEmote {
   removedAt: string;
 }
 
+export interface EmoteListEntry {
+  id: string;
+  name: string;
+  emoteUrl: string;
+}
+
+export interface ActiveEmoteEntry extends EmoteListEntry {
+  addedAt: string;
+}
+
+export interface RemovedEmoteEntry extends EmoteListEntry {
+  removedAt: string;
+}
+
 const fetchEmotes = async <T>(url: string, fn: string): Promise<T> => {
   const res = await fetch(url, { headers: { 'x-api-key': apiKey } });
 

--- a/apps/web/lib/helpers/emote-url.test.ts
+++ b/apps/web/lib/helpers/emote-url.test.ts
@@ -1,0 +1,92 @@
+import type { Emote } from '~/lib/api/emotes-service';
+import { buildEmoteUrl } from './emote-url';
+
+const CDN_BASE = 'https://static-cdn.jtvnw.net/emoticons/v2';
+
+const makeEmote = (overrides: Partial<Emote> = {}): Emote => ({
+  id: 'emotesv2_0ca61620b2ab44eb86a64146078631f9',
+  name: 'danCrazy',
+  images: {
+    url_1x: 'https://example.com/1x',
+    url_2x: 'https://example.com/2x',
+    url_4x: 'https://example.com/4x',
+  },
+  format: ['static', 'animated'],
+  scale: ['1.0', '2.0', '3.0'],
+  theme_mode: ['light', 'dark'],
+  ...overrides,
+});
+
+describe('buildEmoteUrl', () => {
+  it('picks animated, dark, 3.0 when all variants available', () => {
+    const emote = makeEmote();
+
+    expect(buildEmoteUrl(emote)).toBe(
+      `${CDN_BASE}/${emote.id}/animated/dark/3.0`
+    );
+  });
+
+  it('falls back to static when animated unavailable', () => {
+    const emote = makeEmote({ format: ['static'] });
+
+    expect(buildEmoteUrl(emote)).toBe(
+      `${CDN_BASE}/${emote.id}/static/dark/3.0`
+    );
+  });
+
+  it('falls back to light when dark unavailable', () => {
+    const emote = makeEmote({ theme_mode: ['light'] });
+
+    expect(buildEmoteUrl(emote)).toBe(
+      `${CDN_BASE}/${emote.id}/animated/light/3.0`
+    );
+  });
+
+  it('falls back to 1.0 when only 1.0 available', () => {
+    const emote = makeEmote({ scale: ['1.0'] });
+
+    expect(buildEmoteUrl(emote)).toBe(
+      `${CDN_BASE}/${emote.id}/animated/dark/1.0`
+    );
+  });
+
+  it('uses exact values when only one of each option present', () => {
+    const emote = makeEmote({
+      format: ['static'],
+      theme_mode: ['light'],
+      scale: ['2.0'],
+    });
+
+    expect(buildEmoteUrl(emote)).toBe(
+      `${CDN_BASE}/${emote.id}/static/light/2.0`
+    );
+  });
+
+  it('prefers 2.0 over 1.0 when 3.0 absent', () => {
+    const emote = makeEmote({ scale: ['1.0', '2.0'] });
+
+    expect(buildEmoteUrl(emote)).toBe(
+      `${CDN_BASE}/${emote.id}/animated/dark/2.0`
+    );
+  });
+
+  it('handles empty arrays by falling back to lowest precedence value', () => {
+    const emote = makeEmote({
+      format: [] as Emote['format'],
+      theme_mode: [] as Emote['theme_mode'],
+      scale: [] as Emote['scale'],
+    });
+
+    expect(buildEmoteUrl(emote)).toBe(
+      `${CDN_BASE}/${emote.id}/static/light/1.0`
+    );
+  });
+
+  it('matches CDN template structure', () => {
+    const emote = makeEmote({ id: 'abc123' });
+
+    expect(buildEmoteUrl(emote)).toMatch(
+      /^https:\/\/static-cdn\.jtvnw\.net\/emoticons\/v2\/abc123\/(animated|static)\/(dark|light)\/(1\.0|2\.0|3\.0)$/
+    );
+  });
+});

--- a/apps/web/lib/helpers/emote-url.ts
+++ b/apps/web/lib/helpers/emote-url.ts
@@ -1,0 +1,34 @@
+import type { Emote } from '~/lib/api/emotes-service';
+
+const CDN_BASE = 'https://static-cdn.jtvnw.net/emoticons/v2';
+
+const THEME_MODE_PRECEDENCE = ['dark', 'light'] as const;
+const FORMAT_PRECEDENCE = ['animated', 'static'] as const;
+const SCALE_PRECEDENCE = ['3.0', '2.0', '1.0'] as const;
+
+const pickByPrecedence = <T extends string>(
+  availableValues: readonly string[],
+  orderedPrecedence: readonly T[]
+): T => {
+  const preferredValue = orderedPrecedence.find((value) =>
+    availableValues.includes(value)
+  );
+
+  if (preferredValue) {
+    return preferredValue;
+  }
+
+  return (availableValues[0] ??
+    orderedPrecedence[orderedPrecedence.length - 1]) as T;
+};
+
+export const buildEmoteUrl = (emote: Emote): string => {
+  const selectedThemeMode = pickByPrecedence(
+    emote.theme_mode,
+    THEME_MODE_PRECEDENCE
+  );
+  const selectedFormat = pickByPrecedence(emote.format, FORMAT_PRECEDENCE);
+  const selectedScale = pickByPrecedence(emote.scale, SCALE_PRECEDENCE);
+
+  return `${CDN_BASE}/${emote.id}/${selectedFormat}/${selectedThemeMode}/${selectedScale}`;
+};

--- a/apps/web/lib/helpers/index.ts
+++ b/apps/web/lib/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './dayjs';
+export * from './emote-url';
 export * from './utils';

--- a/apps/web/pages/emotes/[channel].tsx
+++ b/apps/web/pages/emotes/[channel].tsx
@@ -6,8 +6,11 @@ import {
   getActiveEmotes,
   getChannels,
   getRemovedEmotes,
+  type ActiveEmoteEntry,
+  type RemovedEmoteEntry,
 } from '~/lib/api/emotes-service';
 import { channelSlug, type Channel } from '~/lib/api/channels';
+import { buildEmoteUrl } from '~/lib/helpers';
 
 type Params = { channel: string };
 
@@ -32,10 +35,28 @@ export async function getServerSideProps(
     return { notFound: true } as const;
   }
 
-  const [activeEmotes, removedEmotes] = await Promise.all([
+  const [rawActiveEmotes, rawRemovedEmotes] = await Promise.all([
     getActiveEmotes(channelParam),
     getRemovedEmotes(channelParam),
   ]);
+
+  const activeEmotes: ActiveEmoteEntry[] = rawActiveEmotes.map(
+    ({ emote, addedAt }) => ({
+      id: emote.id,
+      name: emote.name,
+      emoteUrl: buildEmoteUrl(emote),
+      addedAt,
+    })
+  );
+
+  const removedEmotes: RemovedEmoteEntry[] = rawRemovedEmotes.map(
+    ({ emote, removedAt }) => ({
+      id: emote.id,
+      name: emote.name,
+      emoteUrl: buildEmoteUrl(emote),
+      removedAt,
+    })
+  );
 
   return {
     props: {


### PR DESCRIPTION
## Summary
- Add `buildEmoteUrl` helper (`apps/web/lib/helpers/emote-url.ts`) that picks best variant per precedence (`animated > static`, `dark > light`, `3.0 > 2.0 > 1.0`) and assembles the Twitch CDN URL.
- `getServerSideProps` in `pages/emotes/[channel].tsx` now maps raw fetcher output to thin `{ id, name, emoteUrl, addedAt | removedAt }` entries before serving props — no more shipping the full `images`/`format`/`scale`/`theme_mode` payload to the client.
- `EmoteTabs` / `EmotesList` consume the new `EmoteListEntry` shape; `data-testid` values preserved for Cypress.

## Test plan
- [x] `pnpm test lib/helpers/emote-url.test.ts` — 8/8 green
- [x] `pnpm exec tsc --noEmit` — no new type errors
- [x] `pnpm lint` — no new errors
- [ ] `pnpm dev` then visit `/emotes/<channel>` — verify image renders and `<img src>` matches `https://static-cdn.jtvnw.net/emoticons/v2/{id}/animated/dark/3.0`
- [ ] `pnpm e2e` — Cypress emotes spec still green