### PR TITLE
chore(emotes-service): annotate get-emotes/get-removed-emotes requests

### DIFF
--- a/apps/emotes-service/src/adapters/primary/get-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-emotes/main.go
@@ -21,6 +21,8 @@ type activeEmoteDTO struct {
 }
 
 func handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	apigw.AnnotateRequest(ctx, request)
+
 	channelId := request.PathParameters["channelId"]
 
 	aggregateId, err := event_store.AggregateIdFromChannelId(channelId)

--- a/apps/emotes-service/src/adapters/primary/get-removed-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-removed-emotes/main.go
@@ -21,6 +21,8 @@ type removedEmoteDTO struct {
 }
 
 func handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	apigw.AnnotateRequest(ctx, request)
+
 	channelId := request.PathParameters["channelId"]
 
 	aggregateId, err := event_store.AggregateIdFromChannelId(channelId)

--- a/apps/emotes-service/src/apigw/observability.go
+++ b/apps/emotes-service/src/apigw/observability.go
@@ -31,4 +31,11 @@ func AnnotateRequest(ctx context.Context, req events.APIGatewayProxyRequest) {
 		}
 		txn.AddAttribute(k, v)
 	}
+
+	for k, v := range req.PathParameters {
+		if v == "" {
+			continue
+		}
+		txn.AddAttribute("request.path."+k, v)
+	}
 }


### PR DESCRIPTION
## Summary
- Add `apigw.AnnotateRequest` to `get-emotes` and `get-removed-emotes` lambdas so all APIGW handlers tag New Relic transactions consistently with `get-channels` and `add-channel`.

## Test plan
- [x] `go build ./...` in `apps/emotes-service`
- [ ] Confirm New Relic transactions for `GET /channels/{channelId}/emotes` and `GET /channels/{channelId}/removed-emotes` include `request.http.method`, `request.http.path`, `request.id`, identity attrs after deploy.