### PR TITLE
feat(web): server-side user search on app router

### DIFF
--- a/apps/web/app/user-search/actions.ts
+++ b/apps/web/app/user-search/actions.ts
@@ -11,7 +11,8 @@ export const searchUsernameAction = async (
   _prev: SearchFormState,
   formData: FormData,
 ): Promise<SearchFormState> => {
-  const parsed = usernameSchema.safeParse(formData.values());
+  const username = formData.get('username');
+  const parsed = usernameSchema.safeParse(username);
 
   if (!parsed.success) {
     return { errors: parsed.error.issues.map((issue) => issue.message) };

--- a/apps/web/app/user-search/actions.ts
+++ b/apps/web/app/user-search/actions.ts
@@ -1,0 +1,22 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { usernameSchema } from '~/app/user-search/schemas';
+
+export interface SearchFormState {
+  errors?: string[];
+}
+
+export const searchUsernameAction = async (
+  _prev: SearchFormState,
+  formData: FormData,
+): Promise<SearchFormState> => {
+  const parsed = usernameSchema.safeParse(formData.values());
+
+  if (!parsed.success) {
+    return { errors: parsed.error.issues.map((issue) => issue.message) };
+  }
+
+  // Page server-fetches from searchParams
+  redirect(`/user-search?username=${encodeURIComponent(parsed.data)}`);
+};

--- a/apps/web/app/user-search/page.tsx
+++ b/apps/web/app/user-search/page.tsx
@@ -1,22 +1,28 @@
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
+import UserSearchContent from '~/app/user-search/user-search-content';
+import UserSearchSkeleton from '~/app/user-search/user-search-skeleton';
 import { Heading } from '~/components/shared';
-import { UserSearch } from '~/components/user-search';
 
 export const metadata: Metadata = {
   title: 'User Search | SeriousSloth',
   description: 'Search Twitch users by username.',
 };
 
-const Page = () => {
-  return (
-    <>
-      <div className='mb-6 flex flex-col items-center gap-2 text-center'>
-        <Heading variant='h1'>User Search</Heading>
-        <p>Search Twitch users by username.</p>
-      </div>
-      <UserSearch />
-    </>
-  );
-};
+interface PageProps {
+  searchParams: Promise<{ username?: string }>;
+}
+
+const Page = ({ searchParams }: PageProps) => (
+  <>
+    <div className='mb-6 flex flex-col items-center gap-2 text-center'>
+      <Heading variant='h1'>User Search</Heading>
+      <p>Search Twitch users by username.</p>
+    </div>
+    <Suspense fallback={<UserSearchSkeleton />}>
+      <UserSearchContent searchParams={searchParams} />
+    </Suspense>
+  </>
+);
 
 export default Page;

--- a/apps/web/app/user-search/page.tsx
+++ b/apps/web/app/user-search/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import UserSearchContent from '~/app/user-search/user-search-content';
+import UserSearchForm from '~/app/user-search/user-search-form';
 import UserSearchSkeleton from '~/app/user-search/user-search-skeleton';
-import { Heading } from '~/components/shared';
+import { Card, Heading } from '~/components/shared';
 
 export const metadata: Metadata = {
   title: 'User Search | SeriousSloth',
@@ -19,9 +20,14 @@ const Page = ({ searchParams }: PageProps) => (
       <Heading variant='h1'>User Search</Heading>
       <p>Search Twitch users by username.</p>
     </div>
-    <Suspense fallback={<UserSearchSkeleton />}>
-      <UserSearchContent searchParams={searchParams} />
-    </Suspense>
+    <div className='flex flex-col gap-4'>
+      <Card className='w-full px-2 py-2 md:w-1/2 md:self-center'>
+        <UserSearchForm />
+      </Card>
+      <Suspense fallback={<UserSearchSkeleton />}>
+        <UserSearchContent searchParams={searchParams} />
+      </Suspense>
+    </div>
   </>
 );
 

--- a/apps/web/app/user-search/queries.ts
+++ b/apps/web/app/user-search/queries.ts
@@ -1,0 +1,18 @@
+import { fetchClientCredentials, fetchUsers } from '~/lib/twitch';
+import type { GetUsers } from '~/types/twitch';
+
+export type SearchTwitchUserResult = GetUsers | { error: string };
+
+export const searchTwitchUser = async (
+  username: string,
+): Promise<SearchTwitchUserResult> => {
+  'use cache';
+
+  try {
+    const { access_token } = await fetchClientCredentials();
+    return await fetchUsers(access_token, username);
+  } catch (error) {
+    console.error(error);
+    return { error: 'Unknown error' };
+  }
+};

--- a/apps/web/app/user-search/schemas.ts
+++ b/apps/web/app/user-search/schemas.ts
@@ -1,0 +1,16 @@
+import * as z from 'zod';
+
+const USERNAME_MIN_LENGTH = 3;
+const USERNAME_MAX_LENGTH = 25;
+
+export const usernameSchema = z
+  .string()
+  .min(
+    USERNAME_MIN_LENGTH,
+    `Username must be more than ${USERNAME_MIN_LENGTH - 1} characters`,
+  )
+  .max(
+    USERNAME_MAX_LENGTH,
+    `Username must be less than ${USERNAME_MAX_LENGTH + 1} characters`,
+  )
+  .regex(/^\w+$/, 'Username can only contain alphanumeric characters');

--- a/apps/web/app/user-search/user-search-content.tsx
+++ b/apps/web/app/user-search/user-search-content.tsx
@@ -1,0 +1,31 @@
+import UserSearchForm from '~/app/user-search/user-search-form';
+import { searchTwitchUser } from '~/app/user-search/queries';
+import { usernameSchema } from '~/app/user-search/schemas';
+import { Card } from '~/components/shared';
+import User from '~/components/user-search/user';
+
+interface Props {
+  searchParams: Promise<{ username?: string }>;
+}
+
+const UserSearchContent = async ({ searchParams }: Props) => {
+  const { username } = await searchParams;
+  const parsed = usernameSchema.safeParse(username);
+
+  const result = parsed?.success
+    ? await searchTwitchUser(parsed.data)
+    : undefined;
+
+  const user = result && !('error' in result) ? result : undefined;
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <Card className='w-full px-2 py-2 md:w-1/2 md:self-center'>
+        <UserSearchForm defaultUsername={parsed.data} />
+      </Card>
+      {user ? <User userResponse={user} /> : null}
+    </div>
+  );
+};
+
+export default UserSearchContent;

--- a/apps/web/app/user-search/user-search-content.tsx
+++ b/apps/web/app/user-search/user-search-content.tsx
@@ -1,7 +1,5 @@
-import UserSearchForm from '~/app/user-search/user-search-form';
 import { searchTwitchUser } from '~/app/user-search/queries';
 import { usernameSchema } from '~/app/user-search/schemas';
-import { Card } from '~/components/shared';
 import User from '~/components/user-search/user';
 
 interface Props {
@@ -18,14 +16,7 @@ const UserSearchContent = async ({ searchParams }: Props) => {
 
   const user = result && !('error' in result) ? result : undefined;
 
-  return (
-    <div className='flex flex-col gap-4'>
-      <Card className='w-full px-2 py-2 md:w-1/2 md:self-center'>
-        <UserSearchForm defaultUsername={parsed.data} />
-      </Card>
-      {user ? <User userResponse={user} /> : null}
-    </div>
-  );
+  return user ? <User userResponse={user} /> : null;
 };
 
 export default UserSearchContent;

--- a/apps/web/app/user-search/user-search-form.tsx
+++ b/apps/web/app/user-search/user-search-form.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import { useActionState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Suspense, useActionState } from 'react';
 import { useFormStatus } from 'react-dom';
 import {
   type SearchFormState,
   searchUsernameAction,
 } from '~/app/user-search/actions';
+import { usernameSchema } from '~/app/user-search/schemas';
 import { Button } from '~/components/ui/button';
 import { Field, FieldDescription } from '~/components/ui/field';
 import { Input } from '~/components/ui/input';
 import { Spinner } from '~/components/ui/spinner';
-import { usernameSchema } from '~/app/user-search/schemas';
 
 const initialState: SearchFormState = {};
 
@@ -24,11 +25,11 @@ const SearchButton = () => {
   );
 };
 
-interface Props {
+interface FormProps {
   defaultUsername?: string;
 }
 
-const UserSearchForm = ({ defaultUsername }: Props) => {
+const UserSearchFormUI = ({ defaultUsername }: FormProps) => {
   const [state, formAction] = useActionState(
     searchUsernameAction,
     initialState,
@@ -63,5 +64,17 @@ const UserSearchForm = ({ defaultUsername }: Props) => {
     </form>
   );
 };
+
+const UserSearchFormWithParams = () => {
+  const searchParams = useSearchParams();
+  const defaultUsername = searchParams?.get('username') ?? undefined;
+  return <UserSearchFormUI defaultUsername={defaultUsername} />;
+};
+
+const UserSearchForm = () => (
+  <Suspense fallback={<UserSearchFormUI />}>
+    <UserSearchFormWithParams />
+  </Suspense>
+);
 
 export default UserSearchForm;

--- a/apps/web/app/user-search/user-search-form.tsx
+++ b/apps/web/app/user-search/user-search-form.tsx
@@ -17,11 +17,7 @@ const SearchButton = () => {
   const { pending } = useFormStatus();
 
   return (
-    <Button
-      className='min-w-20'
-      aria-disabled={pending}
-      type={pending ? 'button' : 'submit'}
-    >
+    <Button className='min-w-20' disabled={pending} type='submit'>
       {pending ? <Spinner className='size-4' /> : 'Search'}
     </Button>
   );
@@ -40,11 +36,7 @@ const UserSearchForm = ({ defaultUsername }: Props) => {
 
   return (
     <form action={formAction} role='search'>
-      <Field
-        className='pb-2'
-        orientation='horizontal'
-        data-invalid={hasFormErrors}
-      >
+      <Field orientation='horizontal' data-invalid={hasFormErrors}>
         <Input
           aria-invalid={hasFormErrors}
           autoComplete='off'
@@ -58,9 +50,15 @@ const UserSearchForm = ({ defaultUsername }: Props) => {
         />
         <SearchButton />
       </Field>
-      {state.errors?.map((error) => (
-        <FieldDescription key={error}>{error}</FieldDescription>
-      ))}
+      {state.errors ? (
+        <div className='pt-2 px-2'>
+          {state.errors.map((error) => (
+            <FieldDescription className='first:mt-2' key={error}>
+              {error}
+            </FieldDescription>
+          ))}
+        </div>
+      ) : null}
     </form>
   );
 };

--- a/apps/web/app/user-search/user-search-form.tsx
+++ b/apps/web/app/user-search/user-search-form.tsx
@@ -3,8 +3,8 @@
 import { useActionState } from 'react';
 import { useFormStatus } from 'react-dom';
 import {
-  searchUsernameAction,
   type SearchFormState,
+  searchUsernameAction,
 } from '~/app/user-search/actions';
 import { Button } from '~/components/ui/button';
 import { Field, FieldDescription } from '~/components/ui/field';
@@ -32,12 +32,19 @@ interface Props {
 }
 
 const UserSearchForm = ({ defaultUsername }: Props) => {
-  const [state, formAction] = useActionState(searchUsernameAction, initialState);
+  const [state, formAction] = useActionState(
+    searchUsernameAction,
+    initialState,
+  );
   const hasFormErrors = !!state.errors?.length;
 
   return (
     <form action={formAction} role='search'>
-      <Field orientation='horizontal' data-invalid={hasFormErrors}>
+      <Field
+        className='pb-2'
+        orientation='horizontal'
+        data-invalid={hasFormErrors}
+      >
         <Input
           aria-invalid={hasFormErrors}
           autoComplete='off'

--- a/apps/web/app/user-search/user-search-form.tsx
+++ b/apps/web/app/user-search/user-search-form.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useActionState } from 'react';
+import { useFormStatus } from 'react-dom';
+import {
+  searchUsernameAction,
+  type SearchFormState,
+} from '~/app/user-search/actions';
+import { Button } from '~/components/ui/button';
+import { Field, FieldDescription } from '~/components/ui/field';
+import { Input } from '~/components/ui/input';
+import { Spinner } from '~/components/ui/spinner';
+
+const initialState: SearchFormState = {};
+
+const SearchButton = () => {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button
+      className='min-w-20'
+      aria-disabled={pending}
+      type={pending ? 'button' : 'submit'}
+    >
+      {pending ? <Spinner className='size-4' /> : 'Search'}
+    </Button>
+  );
+};
+
+interface Props {
+  defaultUsername?: string;
+}
+
+const UserSearchForm = ({ defaultUsername }: Props) => {
+  const [state, formAction] = useActionState(searchUsernameAction, initialState);
+  const hasFormErrors = !!state.errors?.length;
+
+  return (
+    <form action={formAction} role='search'>
+      <Field orientation='horizontal' data-invalid={hasFormErrors}>
+        <Input
+          aria-invalid={hasFormErrors}
+          autoComplete='off'
+          defaultValue={defaultUsername}
+          minLength={3}
+          maxLength={120}
+          name='username'
+          placeholder='Search...'
+          required
+          type='search'
+        />
+        <SearchButton />
+      </Field>
+      {state.errors?.map((error) => (
+        <FieldDescription key={error}>{error}</FieldDescription>
+      ))}
+    </form>
+  );
+};
+
+export default UserSearchForm;

--- a/apps/web/app/user-search/user-search-form.tsx
+++ b/apps/web/app/user-search/user-search-form.tsx
@@ -10,6 +10,7 @@ import { Button } from '~/components/ui/button';
 import { Field, FieldDescription } from '~/components/ui/field';
 import { Input } from '~/components/ui/input';
 import { Spinner } from '~/components/ui/spinner';
+import { usernameSchema } from '~/app/user-search/schemas';
 
 const initialState: SearchFormState = {};
 
@@ -41,8 +42,8 @@ const UserSearchForm = ({ defaultUsername }: Props) => {
           aria-invalid={hasFormErrors}
           autoComplete='off'
           defaultValue={defaultUsername}
-          minLength={3}
-          maxLength={120}
+          minLength={usernameSchema.minLength ?? 0}
+          maxLength={usernameSchema.maxLength ?? 0}
           name='username'
           placeholder='Search...'
           required

--- a/apps/web/app/user-search/user-search-skeleton.tsx
+++ b/apps/web/app/user-search/user-search-skeleton.tsx
@@ -9,12 +9,6 @@ const SectionSkeleton = () => (
 
 const UserSearchSkeleton = () => (
   <div className='flex flex-col gap-4'>
-    <Card className='w-full px-2 py-2 md:w-1/2 md:self-center'>
-      <div className='flex items-center gap-2'>
-        <Skeleton className='h-9 flex-1' />
-        <Skeleton className='h-9 w-20' />
-      </div>
-    </Card>
     <Card className='flex w-full flex-col gap-4 p-4 md:p-6'>
       <div className='flex flex-col items-center gap-2 md:flex-row md:gap-4'>
         <Skeleton className='h-20 w-20 md:h-32 md:w-32' />

--- a/apps/web/app/user-search/user-search-skeleton.tsx
+++ b/apps/web/app/user-search/user-search-skeleton.tsx
@@ -1,0 +1,40 @@
+import { Card, Skeleton } from '~/components/shared';
+
+const SectionSkeleton = () => (
+  <div className='flex flex-col gap-2'>
+    <Skeleton className='h-3 w-20' />
+    <Skeleton className='h-4 w-32' />
+  </div>
+);
+
+const UserSearchSkeleton = () => (
+  <div className='flex flex-col gap-4'>
+    <Card className='w-full px-2 py-2 md:w-1/2 md:self-center'>
+      <div className='flex items-center gap-2'>
+        <Skeleton className='h-9 flex-1' />
+        <Skeleton className='h-9 w-20' />
+      </div>
+    </Card>
+    <Card className='flex w-full flex-col gap-4 p-4 md:p-6'>
+      <div className='flex flex-col items-center gap-2 md:flex-row md:gap-4'>
+        <Skeleton className='h-20 w-20 md:h-32 md:w-32' />
+        <div className='flex flex-col items-center gap-2 md:items-start'>
+          <Skeleton className='h-7 w-40' />
+          <Skeleton className='h-4 w-32' />
+        </div>
+      </div>
+      <div className='flex flex-col gap-4 md:flex-row md:gap-12'>
+        <SectionSkeleton />
+        <SectionSkeleton />
+        <SectionSkeleton />
+      </div>
+      <div className='flex flex-col gap-2'>
+        <Skeleton className='h-3 w-32' />
+        <Skeleton className='h-4 w-full' />
+        <Skeleton className='h-4 w-3/4' />
+      </div>
+    </Card>
+  </div>
+);
+
+export default UserSearchSkeleton;

--- a/apps/web/components/user-search/search-form.tsx
+++ b/apps/web/components/user-search/search-form.tsx
@@ -1,5 +1,5 @@
 import autoAnimate from '@formkit/auto-animate';
-import { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { Button, FormErrorMessage, Input, Spinner } from '~/components/shared';

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -2,6 +2,7 @@
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  cacheComponents: true,
   images: {
     remotePatterns: [
       {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,8 @@
     "sharp": "0.33.5",
     "sonner": "2.0.7",
     "tailwind-merge": "3.6.0",
-    "tw-animate-css": "1.4.0"
+    "tw-animate-css": "1.4.0",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@faker-js/faker": "7.6.0",

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "sonner": "2.0.7",
         "tailwind-merge": "3.6.0",
         "tw-animate-css": "1.4.0",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@faker-js/faker": "7.6.0",
@@ -2187,7 +2188,7 @@
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
@@ -2329,8 +2330,6 @@
 
     "@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.4.14", "", {}, "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="],
 
-    "@modelcontextprotocol/sdk/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
     "@next/eslint-plugin-next/fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
 
     "@open-draft/logger/is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
@@ -2344,8 +2343,6 @@
     "@pkgr/utils/picocolors": ["picocolors@1.0.0", "", {}, "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="],
 
     "@pkgr/utils/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
-
-    "@scalar/openapi-types/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@tailwindcss/node/enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
@@ -2518,8 +2515,6 @@
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": "bin/resolve" }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "eslint-plugin-react-hooks/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "execa/cross-spawn": ["cross-spawn@7.0.3", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w=="],
 
@@ -2810,6 +2805,8 @@
     "shadcn/msw": ["msw@2.14.6", "", { "dependencies": { "@inquirer/confirm": "^6.0.11", "@mswjs/interceptors": "^0.41.3", "@open-draft/deferred-promise": "^3.0.0", "@types/statuses": "^2.0.6", "cookie": "^1.1.1", "graphql": "^16.13.2", "headers-polyfill": "^5.0.1", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.11.11", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.1", "type-fest": "^5.5.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg=="],
 
     "shadcn/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "sharp/semver": ["semver@7.7.0", "", { "bin": "bin/semver.js" }, "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ=="],
 


### PR DESCRIPTION
## Summary

Migrates user search to the app router with server-side data fetching.

- **build:** upgrade zod `3.25.76` → `4.4.3`
- **feat:** server action validates input via zod and redirects with the query; cached Twitch query (`'use cache'`); Suspense-driven streaming with a skeleton fallback
- **fix:** import React namespace in legacy `search-form`

Enables `cacheComponents` in `next.config.js` for the `'use cache'` directive.

## Commits

- `build(web): upgrade zod to 4.4.3`
- `fix(web): import React namespace in search-form`
- `feat(web): server-side user search on app router`