### PR TITLE
refactor: cache SSM params via Lambda extension

### DIFF
--- a/apps/emotes-service/infra/components/shared/lambda.go
+++ b/apps/emotes-service/infra/components/shared/lambda.go
@@ -19,6 +19,7 @@ type LambdaArgs struct {
 	ReservedConcurrentExecutions pulumi.IntPtrInput
 	Environment                  pulumi.StringMap
 	PolicyStatements             iam.GetPolicyDocumentStatementArray
+	Layers                       pulumi.StringArray
 }
 
 type Lambda struct {
@@ -159,6 +160,11 @@ func NewLambda(ctx *pulumi.Context, name string, args *LambdaArgs, opts ...pulum
 		envVars[k] = v
 	}
 
+	baseLayers := pulumi.StringArray{
+		pulumi.String("arn:aws:lambda:eu-west-1:451483290750:layer:NewRelicLambdaExtensionARM64:54"),
+	}
+	layers := append(baseLayers, args.Layers...)
+
 	function, err := lambda.NewFunction(ctx, name, &lambda.FunctionArgs{
 		Role:                         lambdaRole.Arn,
 		Runtime:                      pulumi.String("provided.al2023"),
@@ -174,9 +180,7 @@ func NewLambda(ctx *pulumi.Context, name string, args *LambdaArgs, opts ...pulum
 		Architectures: pulumi.StringArray{
 			pulumi.String("arm64"),
 		},
-		Layers: pulumi.StringArray{
-			pulumi.String("arn:aws:lambda:eu-west-1:451483290750:layer:NewRelicLambdaExtensionARM64:54"),
-		},
+		Layers: layers,
 		LoggingConfig: &lambda.FunctionLoggingConfigArgs{
 			ApplicationLogLevel: pulumi.String(logLevel),
 			LogFormat:           pulumi.String("JSON"),

--- a/apps/emotes-service/infra/components/stateless.go
+++ b/apps/emotes-service/infra/components/stateless.go
@@ -57,6 +57,8 @@ func NewStatelessComponent(ctx *pulumi.Context, providerResource pulumi.Resource
 	twitchClientId := appConfig.RequireSecret("twitch-client-id")
 	twitchClientSecret := appConfig.RequireSecret("twitch-client-secret")
 
+	awsParameterSecretLambdaExtension := pulumi.String("arn:aws:lambda:eu-west-1:015030872274:layer:AWS-Parameters-and-Secrets-Lambda-Extension-Arm64:89")
+
 	twitchClientIdParam, err := ssm.NewParameter(ctx, "twitch-client-id", &ssm.ParameterArgs{
 		Type:  pulumi.String(ssm.ParameterTypeSecureString),
 		Value: pulumi.StringInput(twitchClientId),
@@ -90,10 +92,14 @@ func NewStatelessComponent(ctx *pulumi.Context, providerResource pulumi.Resource
 			"TWITCH_CLIENT_ID_PARAM_ARN":      pulumi.StringInput(twitchClientIdParam.Arn),
 			"TWITCH_CLIENT_SECRET_PARAM_ARN":  pulumi.StringInput(twitchClientSecretParam.Arn),
 		},
+		Layers: pulumi.StringArray{awsParameterSecretLambdaExtension},
 		PolicyStatements: iam.GetPolicyDocumentStatementArray{
 			&iam.GetPolicyDocumentStatementArgs{
-				Effect:  pulumi.String("Allow"),
-				Actions: pulumi.StringArray{pulumi.String("ssm:GetParameter")},
+				Effect: pulumi.String("Allow"),
+				Actions: pulumi.StringArray{
+					pulumi.String("kms:Decrypt"),
+					pulumi.String("ssm:GetParameter"),
+				},
 				Resources: pulumi.StringArray{
 					twitchClientIdParam.Arn,
 					twitchClientSecretParam.Arn,
@@ -380,6 +386,7 @@ func NewStatelessComponent(ctx *pulumi.Context, providerResource pulumi.Resource
 			"TWITCH_CLIENT_ID_PARAM_ARN":     pulumi.StringInput(twitchClientIdParam.Arn),
 			"TWITCH_CLIENT_SECRET_PARAM_ARN": pulumi.StringInput(twitchClientSecretParam.Arn),
 		},
+		Layers: pulumi.StringArray{awsParameterSecretLambdaExtension},
 		PolicyStatements: iam.GetPolicyDocumentStatementArray{
 			&iam.GetPolicyDocumentStatementArgs{
 				Effect:    pulumi.String("Allow"),
@@ -387,8 +394,11 @@ func NewStatelessComponent(ctx *pulumi.Context, providerResource pulumi.Resource
 				Resources: pulumi.StringArray{statefulResource.TwitchChannelsTable.Arn},
 			},
 			&iam.GetPolicyDocumentStatementArgs{
-				Effect:  pulumi.String("Allow"),
-				Actions: pulumi.StringArray{pulumi.String("ssm:GetParameter")},
+				Effect: pulumi.String("Allow"),
+				Actions: pulumi.StringArray{
+					pulumi.String("kms:Decrypt"),
+					pulumi.String("ssm:GetParameter"),
+				},
 				Resources: pulumi.StringArray{
 					twitchClientIdParam.Arn,
 					twitchClientSecretParam.Arn,
@@ -445,10 +455,14 @@ func NewStatelessComponent(ctx *pulumi.Context, providerResource pulumi.Resource
 			"TWITCH_CLIENT_ID_PARAM_ARN":      pulumi.StringInput(twitchClientIdParam.Arn),
 			"TWITCH_CLIENT_SECRET_PARAM_ARN":  pulumi.StringInput(twitchClientSecretParam.Arn),
 		},
+		Layers: pulumi.StringArray{awsParameterSecretLambdaExtension},
 		PolicyStatements: iam.GetPolicyDocumentStatementArray{
 			&iam.GetPolicyDocumentStatementArgs{
-				Effect:  pulumi.String("Allow"),
-				Actions: pulumi.StringArray{pulumi.String("ssm:GetParameter")},
+				Effect: pulumi.String("Allow"),
+				Actions: pulumi.StringArray{
+					pulumi.String("kms:Decrypt"),
+					pulumi.String("ssm:GetParameter"),
+				},
 				Resources: pulumi.StringArray{
 					twitchClientIdParam.Arn,
 					twitchClientSecretParam.Arn,

--- a/apps/emotes-service/src/adapters/secondary/parameter/parameter.go
+++ b/apps/emotes-service/src/adapters/secondary/parameter/parameter.go
@@ -2,12 +2,17 @@ package parameter
 
 import (
 	"context"
+	"emotes-service/src/environment"
+	"encoding/json"
 	"log"
 	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 var ssmClient *ssm.Client
@@ -20,16 +25,51 @@ func init() {
 	ssmClient = ssm.NewFromConfig(cfg)
 }
 
+// GetSecret gets a secret from SSM
+// It calls SSM via local host instead of using the SSM client in conjunction with the SSM Lambda Layer.
+// The Lambda Layer provides caching.
+// See: https://aws.amazon.com/blogs/compute/using-the-aws-parameter-and-secrets-lambda-extension-to-cache-parameters-and-secrets/
 func GetSecret(ctx context.Context, nameOrArn string) (string, error) {
-	output, err := ssmClient.GetParameter(ctx,
-		&ssm.GetParameterInput{
-			Name:           aws.String(nameOrArn),
-			WithDecryption: aws.Bool(true),
-		})
+	u := url.URL{
+		Scheme: "http",
+		Host:   "localhost:2773",
+		Path:   "/systemsmanager/parameters/get",
+	}
+
+	q := u.Query()
+	q.Set("name", nameOrArn)
+	q.Set("withDecryption", "true")
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
+		slog.ErrorContext(ctx, "Error creating ssm request", "error", err)
 		return "", err
 	}
 
-	slog.Info("Got secret value", "nameOrArn", nameOrArn)
+	awsSessionToken := environment.GetOrFatal("AWS_SESSION_TOKEN")
+	req.Header.Set("X-Aws-Parameters-Secrets-Token", awsSessionToken)
+
+	client := &http.Client{
+		Timeout:   time.Second * 10,
+		Transport: newrelic.NewRoundTripper(nil),
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.ErrorContext(ctx, "Error ssm parameter", "error", err)
+		return "", err
+	}
+
+	defer resp.Body.Close()
+
+	output := &ssm.GetParameterOutput{}
+	err = json.NewDecoder(resp.Body).Decode(output)
+
+	if err != nil {
+		slog.ErrorContext(ctx, "Error ssm parameter response", "error", err)
+		return "", err
+	}
+
 	return *output.Parameter.Value, nil
 }


### PR DESCRIPTION
## Summary

Cache Twitch client credentials with the AWS Parameters and Secrets Lambda Extension instead of calling SSM directly on every invocation.

- Add the extension layer to the Twitch-backed Lambdas and grant `kms:Decrypt` so it can read `SecureString` parameters
- Expose a configurable `Layers` field on the shared Lambda component
- Fetch parameters over the extension's `localhost:2773` endpoint, traced via New Relic

## Why

SSM `GetParameter` ran per cold path. The extension caches locally, cutting SSM calls and latency.
