### PR TITLE
fix(twitch): wait for errgroup before using secrets

### DIFF
--- a/apps/emotes-service/go.mod
+++ b/apps/emotes-service/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.2
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.0
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.5
 	github.com/newrelic/go-agent/v3 v3.43.3
 	github.com/newrelic/go-agent/v3/integrations/nrlambda v1.2.6
@@ -18,6 +19,7 @@ require (
 	github.com/pulumi/pulumi/sdk/v3 v3.232.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 )
 
 require (
@@ -39,7 +41,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.10 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.0 // indirect
@@ -133,7 +134,6 @@ require (
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/apps/emotes-service/src/adapters/secondary/twitch/twitch.go
+++ b/apps/emotes-service/src/adapters/secondary/twitch/twitch.go
@@ -38,6 +38,10 @@ func GetAccessToken(ctx context.Context) (string, error) {
 		return err
 	})
 
+	if err := g.Wait(); err != nil {
+		return "", err
+	}
+
 	oauth2Config := &clientcredentials.Config{
 		ClientID:     twitchClientId,
 		ClientSecret: twitchClientSecret,

--- a/apps/emotes-service/src/adapters/secondary/twitch/twitch.go
+++ b/apps/emotes-service/src/adapters/secondary/twitch/twitch.go
@@ -52,9 +52,11 @@ func GetAccessToken(ctx context.Context) (string, error) {
 		Timeout:   time.Second * 10,
 		Transport: newrelic.NewRoundTripper(nil),
 	})
+
 	token, err := oauth2Config.Token(tokenCtx)
+
 	if err != nil {
-		slog.Error("Error getting access token", "error", err)
+		slog.ErrorContext(ctx, "Error getting access token", "error", err)
 		return "", err
 	}
 

--- a/apps/emotes-service/src/adapters/secondary/twitch/twitch.go
+++ b/apps/emotes-service/src/adapters/secondary/twitch/twitch.go
@@ -20,20 +20,20 @@ import (
 func GetAccessToken(ctx context.Context) (string, error) {
 	var twitchClientId, twitchClientSecret string
 
-	g, ctx := errgroup.WithContext(ctx)
+	g, gCtx := errgroup.WithContext(ctx)
 
 	g.Go(func() (err error) {
-		twitchClientId, err = parameter.GetSecret(ctx, environment.GetOrFatal("TWITCH_CLIENT_ID_PARAM_ARN"))
+		twitchClientId, err = parameter.GetSecret(gCtx, environment.GetOrFatal("TWITCH_CLIENT_ID_PARAM_ARN"))
 		if err != nil {
-			slog.ErrorContext(ctx, "Error getting client id", "error", err)
+			slog.ErrorContext(gCtx, "Error getting client id", "error", err)
 		}
 		return err
 	})
 
 	g.Go(func() (err error) {
-		twitchClientSecret, err = parameter.GetSecret(ctx, environment.GetOrFatal("TWITCH_CLIENT_SECRET_PARAM_ARN"))
+		twitchClientSecret, err = parameter.GetSecret(gCtx, environment.GetOrFatal("TWITCH_CLIENT_SECRET_PARAM_ARN"))
 		if err != nil {
-			slog.ErrorContext(ctx, "Error getting client secret", "error", err)
+			slog.ErrorContext(gCtx, "Error getting client secret", "error", err)
 		}
 		return err
 	})


### PR DESCRIPTION
## Problem
Since #47 (`a2894a7`), all Twitch authentication fails in prod:
```
oauth2: cannot fetch token: 400 Bad Request
Response: {"status":400,"message":"missing client id"}
```

## Root cause
`GetAccessToken` parallelised the client id / secret SSM lookups via `errgroup`, but never called `g.Wait()`. Execution fell through to build `clientcredentials.Config` and call `.Token()` while the goroutines were still running, so `ClientID`/`ClientSecret` were empty strings. Twitch rejects the empty client id with HTTP 400.

## Fix
- Add `g.Wait()` barrier before consuming the secrets (propagates fetch errors, which are already logged per-goroutine).
- Promote `golang.org/x/sync` to a direct dependency (`go mod tidy`) since errgroup is now used directly.

## Verification
- `go build ./...` ✅
- `go vet ./src/adapters/secondary/twitch/...` ✅
- lint (pre-commit) ✅
- Post-deploy: confirm NewRelic no longer logs "missing client id" on `emotes-service-channel-sync`.