### PR TITLE
fix(newrelic): read config from environment variables

### DIFF
--- a/apps/emotes-service/infra/components/shared/lambda.go
+++ b/apps/emotes-service/infra/components/shared/lambda.go
@@ -147,7 +147,7 @@ func NewLambda(ctx *pulumi.Context, name string, args *LambdaArgs, opts ...pulum
 		"NEW_RELIC_ACCOUNT_ID":                     pulumi.StringInput(newRelicAccountId),
 		"NEW_RELIC_APM_LAMBDA_MODE":                pulumi.String(newRelicEnabled),
 		"NEW_RELIC_DISTRIBUTED_TRACING_ENABLED":    pulumi.String(newRelicEnabled),
-		"NEW_RELIC_APP_NAME":                       pulumi.String(ctx.Project()),
+		"NEW_RELIC_APP_NAME":                       pulumi.String(ctx.Project() + "-" + ctx.Stack()),
 		"NEW_RELIC_CLOUD_AWS_ACCOUNT_ID":           pulumi.String(awsAccountId),
 		"NEW_RELIC_LICENSE_KEY_SSM_PARAMETER_NAME": pulumi.StringInput(newRelicLambdaLicenseKeySSMParameterArn),
 		"NEW_RELIC_LOG_LEVEL":                      pulumi.String(logLevel),

--- a/apps/emotes-service/src/adapters/primary/add-channel/main.go
+++ b/apps/emotes-service/src/adapters/primary/add-channel/main.go
@@ -71,7 +71,7 @@ func main() {
 		),
 	)
 	slog.SetDefault(logger)
-	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
 	if nil != err {
 		slog.Error("error creating app (invalid config)", "error", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/channel-sync-dispatcher/main.go
+++ b/apps/emotes-service/src/adapters/primary/channel-sync-dispatcher/main.go
@@ -26,7 +26,7 @@ func main() {
 	)
 	slog.SetDefault(logger)
 
-	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
 	if err != nil {
 		slog.Error("error creating app (invalid config)", "err", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/channel-sync/main.go
+++ b/apps/emotes-service/src/adapters/primary/channel-sync/main.go
@@ -66,7 +66,7 @@ func main() {
 	)
 	slog.SetDefault(logger)
 
-	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
 	if err != nil {
 		slog.Error("error creating app (invalid config)", "err", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/emotes-read-model-producer/main.go
+++ b/apps/emotes-service/src/adapters/primary/emotes-read-model-producer/main.go
@@ -40,7 +40,7 @@ func main() {
 	)
 	slog.SetDefault(logger)
 
-	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
 	if nil != err {
 		slog.Error("error creating app (invalid config)", "error", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/get-channels/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-channels/main.go
@@ -44,7 +44,7 @@ func main() {
 		),
 	)
 	slog.SetDefault(logger)
-	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
 	if nil != err {
 		slog.Error("error creating app (invalid config)", "error", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/get-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-emotes/main.go
@@ -59,7 +59,7 @@ func main() {
 		),
 	)
 	slog.SetDefault(logger)
-	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
 	if nil != err {
 		slog.Error("error creating app (invalid config)", "error", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/get-removed-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-removed-emotes/main.go
@@ -59,7 +59,7 @@ func main() {
 		),
 	)
 	slog.SetDefault(logger)
-	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
 	if nil != err {
 		slog.Error("error creating app (invalid config)", "error", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/mock-twitch-api/main.go
+++ b/apps/emotes-service/src/adapters/primary/mock-twitch-api/main.go
@@ -54,7 +54,7 @@ func main() {
 		),
 	)
 	slog.SetDefault(logger)
-	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
 	if nil != err {
 		slog.Error("error creating app (invalid config)", "error", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/sync-global-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/sync-global-emotes/main.go
@@ -26,7 +26,7 @@ func main() {
 	)
 	slog.SetDefault(logger)
 
-	app, err := newrelic.NewApplication(nrlambda.ConfigOption())
+	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
 	if err != nil {
 		slog.Error("error creating app (invalid config)", "err", err)
 	}


### PR DESCRIPTION
## What

- Swap `nrlambda.ConfigOption()` → `newrelic.ConfigFromEnvironment()` across all emotes-service Lambda handlers (10 files).
- Set `NEW_RELIC_APP_NAME` to `project-stack` in shared Lambda infra.

## Why

`nrlambda.ConfigOption()` ignored the `NEW_RELIC_*` env vars, so the app config (name, distributed tracing) was never applied. `ConfigFromEnvironment()` reads them. The app-name change makes environments distinguishable in New Relic.

## Notes

`nrlambda.Start` still used, so no dead imports.