### PR TITLE
fix(newrelic): keep serverless mode when reading env config

### DIFF
--- a/apps/emotes-service/src/adapters/primary/add-channel/main.go
+++ b/apps/emotes-service/src/adapters/primary/add-channel/main.go
@@ -71,7 +71,10 @@ func main() {
 		),
 	)
 	slog.SetDefault(logger)
-	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
+	app, err := newrelic.NewApplication(
+		nrlambda.ConfigOption(),
+		newrelic.ConfigFromEnvironment(),
+	)
 	if nil != err {
 		slog.Error("error creating app (invalid config)", "error", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/channel-sync-dispatcher/main.go
+++ b/apps/emotes-service/src/adapters/primary/channel-sync-dispatcher/main.go
@@ -26,7 +26,10 @@ func main() {
 	)
 	slog.SetDefault(logger)
 
-	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
+	app, err := newrelic.NewApplication(
+		nrlambda.ConfigOption(),
+		newrelic.ConfigFromEnvironment(),
+	)
 	if err != nil {
 		slog.Error("error creating app (invalid config)", "err", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/channel-sync/main.go
+++ b/apps/emotes-service/src/adapters/primary/channel-sync/main.go
@@ -66,7 +66,10 @@ func main() {
 	)
 	slog.SetDefault(logger)
 
-	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
+	app, err := newrelic.NewApplication(
+		nrlambda.ConfigOption(),
+		newrelic.ConfigFromEnvironment(),
+	)
 	if err != nil {
 		slog.Error("error creating app (invalid config)", "err", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/emotes-read-model-producer/main.go
+++ b/apps/emotes-service/src/adapters/primary/emotes-read-model-producer/main.go
@@ -40,7 +40,10 @@ func main() {
 	)
 	slog.SetDefault(logger)
 
-	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
+	app, err := newrelic.NewApplication(
+		nrlambda.ConfigOption(),
+		newrelic.ConfigFromEnvironment(),
+	)
 	if nil != err {
 		slog.Error("error creating app (invalid config)", "error", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/get-channels/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-channels/main.go
@@ -44,7 +44,10 @@ func main() {
 		),
 	)
 	slog.SetDefault(logger)
-	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
+	app, err := newrelic.NewApplication(
+		nrlambda.ConfigOption(),
+		newrelic.ConfigFromEnvironment(),
+	)
 	if nil != err {
 		slog.Error("error creating app (invalid config)", "error", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/get-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-emotes/main.go
@@ -59,7 +59,10 @@ func main() {
 		),
 	)
 	slog.SetDefault(logger)
-	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
+	app, err := newrelic.NewApplication(
+		nrlambda.ConfigOption(),
+		newrelic.ConfigFromEnvironment(),
+	)
 	if nil != err {
 		slog.Error("error creating app (invalid config)", "error", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/get-removed-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/get-removed-emotes/main.go
@@ -59,7 +59,10 @@ func main() {
 		),
 	)
 	slog.SetDefault(logger)
-	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
+	app, err := newrelic.NewApplication(
+		nrlambda.ConfigOption(),
+		newrelic.ConfigFromEnvironment(),
+	)
 	if nil != err {
 		slog.Error("error creating app (invalid config)", "error", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/mock-twitch-api/main.go
+++ b/apps/emotes-service/src/adapters/primary/mock-twitch-api/main.go
@@ -54,7 +54,10 @@ func main() {
 		),
 	)
 	slog.SetDefault(logger)
-	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
+	app, err := newrelic.NewApplication(
+		nrlambda.ConfigOption(),
+		newrelic.ConfigFromEnvironment(),
+	)
 	if nil != err {
 		slog.Error("error creating app (invalid config)", "error", err)
 	}

--- a/apps/emotes-service/src/adapters/primary/sync-global-emotes/main.go
+++ b/apps/emotes-service/src/adapters/primary/sync-global-emotes/main.go
@@ -26,7 +26,10 @@ func main() {
 	)
 	slog.SetDefault(logger)
 
-	app, err := newrelic.NewApplication(newrelic.ConfigFromEnvironment())
+	app, err := newrelic.NewApplication(
+		nrlambda.ConfigOption(),
+		newrelic.ConfigFromEnvironment(),
+	)
 	if err != nil {
 		slog.Error("error creating app (invalid config)", "err", err)
 	}


### PR DESCRIPTION
## What

Pass `nrlambda.ConfigOption()` alongside `newrelic.ConfigFromEnvironment()` in all emotes-service Lambda handlers.

## Why

Follow-up to #49. `ConfigFromEnvironment()` alone leaves `ServerlessMode` disabled, so `newrelic.NewApplication` requires a 40-char `NEW_RELIC_LICENSE_KEY`. Lambdas don't set that env var — the license comes from the SSM parameter via the New Relic extension — so `NewApplication` returned `invalid config` (seen in logs as `error creating app (invalid config)`).

`nrlambda.ConfigOption()` re-enables serverless mode (no license key needed) while `ConfigFromEnvironment()` still applies the env values, including `NEW_RELIC_APP_NAME`. The two options touch different fields, no conflict.

## Verify

- `go build ./src/adapters/primary/...` ✅
- `go vet ./src/adapters/primary/...` ✅